### PR TITLE
Mongo setup now works with remote hosts.

### DIFF
--- a/assets/mongo_setup.js
+++ b/assets/mongo_setup.js
@@ -36,6 +36,5 @@ var sdef = {
     }
 };
 
-conn = new Mongo();
-db = conn.getDB("supremm");
+db = db.getSiblingDB("supremm");
 db.schema.insert(sdef)


### PR DESCRIPTION
To run the setup script to connect to a mongo instance on a remote
host, then use the following syntax:

    mongo --host REMOTE_HOST assets/mongo_setup.js