### PR TITLE
Python 2.6 support

### DIFF
--- a/supremm/indexarchives.py
+++ b/supremm/indexarchives.py
@@ -178,7 +178,8 @@ def runindexing():
 
     logging.basicConfig(format='%(asctime)s [%(levelname)s] %(message)s',
                         datefmt='%Y-%m-%dT%H:%M:%S', level=opts['log'])
-    logging.captureWarnings(True)
+    if sys.version.startswith("2.7"):
+        logging.captureWarnings(True)
 
     config = Config(opts['config'])
 

--- a/supremm/ingest_jobscripts.py
+++ b/supremm/ingest_jobscripts.py
@@ -169,7 +169,8 @@ def main():
     opts = getoptions()
 
     logging.basicConfig(format='%(asctime)s [%(levelname)s] %(message)s', datefmt='%Y-%m-%dT%H:%M:%S', level=opts['log'])
-    logging.captureWarnings(True)
+    if sys.version.startswith("2.7"):
+        logging.captureWarnings(True)
 
     config = Config(opts['config'])
 

--- a/supremm/outputter.py
+++ b/supremm/outputter.py
@@ -12,7 +12,7 @@ class factory(object):
         elif outconf['db_engine'] == "stdout":
             self._impl = StdoutOutput(outconf, resconf)
         else:
-            raise Exception("Unsupported output mechanism {}".format(outconf['db_engine']))
+            raise Exception("Unsupported output mechanism {0}".format(outconf['db_engine']))
 
     def __enter__(self):
         return self._impl.__enter__()

--- a/supremm/preprocessors/SlurmProc.py
+++ b/supremm/preprocessors/SlurmProc.py
@@ -95,7 +95,7 @@ class SlurmProc(PreProcessor):
 
         for pid, idx in currentpids.iteritems():
             if pid not in description[1]:
-                self.logerror("missing process name for pid {}".format(pid))
+                self.logerror("missing process name for pid {0}".format(pid))
                 continue
 
             command = " ".join(description[1][pid].split(" ")[1:])

--- a/supremm/summarize.py
+++ b/supremm/summarize.py
@@ -64,10 +64,10 @@ class Summarize(object):
                 self.archives_processed += 1
             except pmapi.pmErr as exc:
                 success -= 1
-                self.adderror("archive", "{}: pmapi.pmErr: {}".format(archive, exc.message()))
+                self.adderror("archive", "{0}: pmapi.pmErr: {1}".format(archive, exc.message()))
             except Exception as exc:
                 success -= 1
-                self.adderror("archive", "{}: Exception: {}. {}".format(archive, str(exc), traceback.format_exc()))
+                self.adderror("archive", "{0}: Exception: {1}. {2}".format(archive, str(exc), traceback.format_exc()))
 
         return success == 0
 
@@ -314,7 +314,7 @@ class Summarize(object):
         Store the detail of archive processing errors
         """
         logging.debug("archive processing exception: %s %s %s", archive, analyticname, pmerrorcode)
-        self.adderror("archive", "{} {} {}".format(archive, analyticname, pmerrorcode))
+        self.adderror("archive", "{0} {1} {2}".format(archive, analyticname, pmerrorcode))
 
     @staticmethod
     def getdescription(ctx, metric_id_array):

--- a/supremm/summarize_jobs.py
+++ b/supremm/summarize_jobs.py
@@ -227,7 +227,8 @@ def main():
     opts = getoptions()
 
     logging.basicConfig(format='%(asctime)s [%(levelname)s] %(message)s', datefmt='%Y-%m-%dT%H:%M:%S', level=opts['log'])
-    logging.captureWarnings(True)
+    if sys.version.startswith("2.7"):
+        logging.captureWarnings(True)
 
     config = Config()
 


### PR DESCRIPTION
captureWarnings does not exist in 2.6 logging
filter() must use positional arguments in 2.6