### PR TITLE
Add support for building Centos 6 RPMs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ For more information, questions, feedback or bug reports send email to
 Want to be notified about SUPReMM package releases and news? Subscribe to the
 [XDMoD mailing list][listserv].
 
+Software Build Requirements 
+---------------------------
+
+### Centos 6 & 7
+
+Install the PCP repository configuration following the instructions on the [pcp packages
+page][pcpbintray]. Install the EPEL repository configuration:
+
+    yum install epel-release
+
+Install the build dependencies:
+
+    yum install rpm-build pcp-libs-devel gcc python-devel
+
 Installation
 ------------
 
@@ -61,3 +75,4 @@ the [GNU Lesser General Public License ("LGPL") Version 3.0][lgpl3].
 [listserv]:   http://listserv.buffalo.edu/cgi-bin/wa?SUBED1=ccr-xdmod-list&A=1
 [ghpr]:       https://help.github.com/articles/using-pull-requests/
 [pydist]:     https://docs.python.org/2.7/distutils/index.html
+[pcpbintray]: https://bintray.com/pcp/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,4 @@
 [bdist_rpm]
-release = 1
-requires = python-pymongo numpy scipy MySQL-python python-pcp pcp
+release = 1%{?dist}
+build_requires = python-devel pcp-libs-devel
+requires = python-pymongo numpy scipy MySQL-python python-pcp pcp %{?el6:python-backport_collections}

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-""" setup script for SUPReMM summarization package """
+""" setup script for SUPReMM job summarization utilities """
 from distutils.core import setup, Extension
 import sys
 import os
@@ -13,11 +13,13 @@ else:
 
 
 setup(name='supremm',
-      version='0.9.0',
-      description='Python Distribution Utilities',
+      version='0.9.1',
+      description='SUPReMM Job Summarization Utilities',
+      long_description='Utilities for generating job-level summary data from host level PCP archives.\nAlso includes template configuration files for running PCP on an HPC system.',
+      license='LGPLv3',
       author='Joseph P White',
       author_email='jpwhite4@buffalo.edu',
-      url='https://github.com/ubccr/ccr-pcp',
+      url='https://github.com/ubccr/supremm',
       packages=['supremm', 'supremm.pcpfast', 'supremm.plugins', 'supremm.preprocessors'],
       data_files=[(confpath,                         ['config/config.json']),
                   ('share/supremm/templates/slurm',       ['config/templates/slurm/slurm-epilog',  'config/templates/slurm/slurm-prolog']),


### PR DESCRIPTION
- Update build dependency documentation
- setup.cfg file appends dist to rpm name and uses correct rpm requirements for Centos 6
- add RPM build requirements, license and description
- Update RPM version number