### PR TITLE
Allow preprocs to output results.

### DIFF
--- a/supremm/plugin.py
+++ b/supremm/plugin.py
@@ -120,7 +120,8 @@ class PreProcessor(object):
     """
     Preprocessors are called on each archive before all of the plugins are
     run. The results of the preprocessor are therefore available to the plugins.
-    The preprocessor results should be added to the job object.
+    The preprocessor results should be added to the job object by the preprocessor
+    using the job.addata() function.
     """
     __metaclass__ = ABCMeta
 
@@ -151,6 +152,13 @@ class PreProcessor(object):
         """ Called by the framework for all datapoints collected for the host
             referenced in the preceeding call to hoststart. It a host has no data
             then this will not be called.
+        """
+        pass
+
+    @abstractmethod
+    def results(self):
+        """ preprocessors may return a results object that will be added to the summary
+        document.
         """
         pass
 

--- a/supremm/summarize.py
+++ b/supremm/summarize.py
@@ -13,7 +13,7 @@ from supremm.plugin import NodeMetadata
 import numpy
 import copy
 
-VERSION = "1.0.4"
+VERSION = "1.0.5"
 TIMESERIES_VERSION = 4
 
 
@@ -111,13 +111,14 @@ class Summarize(object):
             timeseries['version'] = TIMESERIES_VERSION
             output['timeseries'] = timeseries
 
-        # TODO - this breaks the plugin model a bit - workout how to make it nicer
-        p = self.job.getdata('proc')
-        if p:
-            output['acct']['hostcores'] = [(x[0], list(x[1])) for x in p['cpusallowed'].iteritems()]
-            output['procDump'] = {"constrained": list(p['procDump']['constrained']), "unconstrained": list(p['procDump']['unconstrained'])}
-            if len(p['errors']) > 0:
-                self.adderror("proc", str(p['errors']))
+        for preproc in self.preprocs:
+            result = preproc.results()
+            if result != None:
+                output.update(result)
+
+        for source, data in self.job.data().iteritems():
+            if 'errors' in data:
+                self.adderror(source, str(data['errors']))
 
         if len(self.errors) > 0:
             output['errors'] = {}


### PR DESCRIPTION
This resolves the TODO in the code to abstract out the preprocessor
plugin details from the main handler code. Preprocessors now have a
mandatory results() function, the return value of which will be added
to the job summary. Preproc errors are also added to the job summary
doc too.