### PR TITLE
Handle rare case where kernel.percpu metrics missing.

### DIFF
--- a/supremm/plugins/CpuUsage.py
+++ b/supremm/plugins/CpuUsage.py
@@ -45,6 +45,9 @@ class CpuUsage(Plugin):
         elif len(data) != self._ncpumetrics:
             return False
 
+        if data[0].size == 0:
+            return False
+
         if nodemeta.nodename not in self._first:
             self._first[nodemeta.nodename] = numpy.array(data)
             return True


### PR DESCRIPTION
Seen on a few nodes on the CCR HPC resource where the CPU information
dissapears from the kernel.percpu metrics. Handle this case gracefully.