### PR TITLE
Fix issues in timeseries plugins

### DIFF
--- a/supremm/plugins/MemBwTimeseries.py
+++ b/supremm/plugins/MemBwTimeseries.py
@@ -57,7 +57,7 @@ class MemBwTimeseries(Plugin):
 
         if nodemeta.nodeindex not in self._hostdata:
             self._hostdata[hostidx] = numpy.empty((TimeseriesAccumulator.MAX_DATAPOINTS, len(data[1])))
-            self._hostdevnames[hostidx] = dict((str(k), v) for k, v in zip(description[0][0], description[0][1]))
+            self._hostdevnames[hostidx] = dict((str(k), v) for k, v in zip(description[1][0], description[1][1]))
 
         membw = 64.0 * numpy.sum(data[1:]) / 1024.0 / 1024.0 / 1024.0
 

--- a/supremm/plugins/SimdInsTimeseries.py
+++ b/supremm/plugins/SimdInsTimeseries.py
@@ -53,7 +53,7 @@ class SimdInsTimeseries(Plugin):
 
         if nodemeta.nodeindex not in self._hostdata:
             self._hostdata[hostidx] = numpy.empty((TimeseriesAccumulator.MAX_DATAPOINTS, len(data[1])))
-            self._hostdevnames[hostidx] = dict((str(k), v) for k, v in zip(description[0][0], description[0][1]))
+            self._hostdevnames[hostidx] = dict((str(k), v) for k, v in zip(description[1][0], description[1][1]))
 
         if len(data) == len(NHM_METRICS):
             flops = numpy.array(data[1])


### PR DESCRIPTION
Plugin grabbed wrong value from description array, which made dev and name catigories be empty. 