### PR TITLE
Ensure config files are marked %config in spec file.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,4 @@
 release = 1%{?dist}
 build_requires = python-devel pcp-libs-devel
 requires = python-pymongo numpy scipy MySQL-python python-pcp pcp %{?el6:python-backport_collections}
+install_script = .rpm_install_script.txt

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,15 @@ import sys
 import os
 
 # For rpm-based builds want the configuration files to
-# go in the standard location
+# go in the standard location. Also need to rewrite the file list so that
+# the config filesa are listed as %config(noreplace)
+IS_RPM_BUILD = False
 if 'bdist_rpm' in sys.argv or 'RPM_BUILD_ROOT' in os.environ:
+    IS_RPM_BUILD = True
     confpath = '/etc/supremm'
+    with open('.rpm_install_script.txt', 'w') as fp:
+        fp.write('%s %s install -O1 --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES\n' % (sys.executable, os.path.basename(sys.argv[0])))
+        fp.write('sed -i \'s#^\\(%s\\)#%%config(noreplace) \\1#\' INSTALLED_FILES\n' % (confpath, ))
 else:
     confpath = 'etc/supremm'
 
@@ -42,3 +48,6 @@ setup(name='supremm',
                 'pcp'],
       ext_modules=[Extension('supremm.pcpfast.libpcpfast', ['supremm/pcpfast/pcpfast.c'], libraries=['pcp'])]
      )
+
+if IS_RPM_BUILD:
+    os.unlink('.rpm_install_script.txt')


### PR DESCRIPTION
Unfortunately setup tools do not support this natively, so we use a workaround
that generates an install script that has %config(noreplace) for all files in the
config directory.