### PR TITLE
Added support for metrics from BlueWaters

### DIFF
--- a/assets/mongo_setup.js
+++ b/assets/mongo_setup.js
@@ -18,6 +18,11 @@ var sdef = {
             "description": "SIMD instructions",
             "help": "The total rate of floating point SIMD instructions reported by the hardware performance counters on the CPU cores on which the job ran. Note that the meaning of this value is hardware-specific so the data should not in general be compared between HPC resources that have different hardware architectures."
         },
+        "clktks": {
+            "units": "insts/s",
+            "description": "Clock Ticks",
+            "help": "The total rate of clock ticks reported by the hardware performance counters on the CPU cores on which the job ran. Note that the meaning of this value is hardware-specific so the data should not in general be compared between HPC resources that have different hardware architectures."
+        },
         "memused_minus_diskcache": {
             "units": "GB",
             "description": "Node Memory RSS",
@@ -57,8 +62,8 @@ var sdef = {
 };
 
 var summarydef = {
-    "summary_version": "summary-1.0.5", 
-    "_id": "summary-1.0.5",
+    "summary_version": "summary-1.0.6",
+    "_id": "summary-1.0.6",
     "definitions": {
         "lnet": {
             "documentation": "", 
@@ -105,6 +110,28 @@ var summarydef = {
             "type": "", 
             "unit": ""
         }, 
+        "nodememory": {
+            "free": {
+                "documentation": "The average amount of free memory per node for the job. The value is obtained from /proc/meminfo. The average is calculated as the mean value of each memory usage measurement.",
+                "type": "instant",
+                "unit": "byte"
+            },
+            "maxfree": {
+                "documentation": "The maximum value of the free memory on a node.",
+                "type": "instant",
+                "unit": "byte"
+            },
+            "used": {
+                "documentation": "The average amount of used memory per node.",
+                "type": "instant",
+                "unit": "byte"
+            },
+            "maxused": {
+                "documentation": "The maximum value of the used memory on a node.",
+                "type": "instant",
+                "unit": "byte"
+            }
+        },
         "process_memory": {
             "usage": {
                 "avg": {

--- a/supremm/plugins/BlueWaters.py
+++ b/supremm/plugins/BlueWaters.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+from supremm.plugin import DeviceInstanceBasedPlugin
+
+class BlueWaters(DeviceInstanceBasedPlugin):
+    """ Process bluewaters-specific metrics """
+
+    name = property(lambda x: "bluewaters")
+    requiredMetrics = property(lambda x: [
+        "bluewaters.SMSG_ntx",
+        "bluewaters.SMSG_tx_bytes",
+        "bluewaters.SMSG_nrx",
+        "bluewaters.SMSG_rx_bytes",
+        "bluewaters.RDMA_ntx",
+        "bluewaters.RDMA_tx_bytes",
+        "bluewaters.RDMA_nrx",
+        "bluewaters.RDMA_rx_bytes"
+        ])
+    optionalMetrics = property(lambda x: [])
+    derivedMetrics = property(lambda x: [])
+

--- a/supremm/plugins/Catastrophe.py
+++ b/supremm/plugins/Catastrophe.py
@@ -11,7 +11,8 @@ class Catastrophe(Plugin):
     name = property(lambda x: "catastrophe")
     mode = property(lambda x: "all")
     requiredMetrics = property(lambda x: [["perfevent.hwcounters.MEM_LOAD_RETIRED_L1D_HIT.value", "perfevent.active"], 
-                                          ["perfevent.hwcounters.L1D_REPLACEMENT.value", "perfevent.active"]])
+                                          ["perfevent.hwcounters.L1D_REPLACEMENT.value", "perfevent.active"],
+                                          ["perfevent.hwcounters.DATA_CACHE_MISSES_DC_MISS_STREAMING_STORE.value", "perfevent.active"]])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 

--- a/supremm/plugins/CpuPerfCounters.py
+++ b/supremm/plugins/CpuPerfCounters.py
@@ -20,13 +20,17 @@ NHM_METRICS = ["perfevent.hwcounters.UNHALTED_REFERENCE_CYCLES.value",
                "perfevent.hwcounters.MEM_LOAD_RETIRED_L1D_HIT.value",
                "perfevent.hwcounters.FP_COMP_OPS_EXE_SSE_FP.value"]
 
+AMD_INTERLAGOS_METRICS = ["perfevent.hwcounters.CPU_CLK_UNHALTED.value",
+                          "perfevent.hwcounters.RETIRED_INSTRUCTIONS.value",
+                          "perfevent.hwcounters.DATA_CACHE_MISSES_DC_MISS_STREAMING_STORE.value",
+                          "perfevent.hwcounters.RETIRED_SSE_OPS_ALL.value"]
 
 class CpuPerfCounters(Plugin):
     """ Compute various performance counter derived metrics """
 
     name = property(lambda x: "cpuperf")
     mode = property(lambda x: "firstlast")
-    requiredMetrics = property(lambda x: [SNB_METRICS, NHM_METRICS])
+    requiredMetrics = property(lambda x: [SNB_METRICS, NHM_METRICS, AMD_INTERLAGOS_METRICS])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
@@ -71,7 +75,7 @@ class CpuPerfCounters(Plugin):
 
         coreindex = 0
         for _, data in self._data.iteritems():
-            if len(data) == len(NHM_METRICS):
+            if len(data) == len(NHM_METRICS): # also covers the AMD_INTERLAGOS
                 flops[coreindex:coreindex + len(data[0])] = 1.0 * data[3]
                 cpiref[coreindex:coreindex + len(data[0])] = 1.0 * data[0] / data[1]
                 cpldref[coreindex:coreindex + len(data[0])] = 1.0 * data[0] / data[2]

--- a/supremm/plugins/CrayGemini.py
+++ b/supremm/plugins/CrayGemini.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+from supremm.plugin import DeviceInstanceBasedPlugin
+
+class CrayGemini(DeviceInstanceBasedPlugin):
+    """ Metrics from the Cray Gemini interconnect """
+
+    name = property(lambda x: "gemini")
+    requiredMetrics = property(lambda x: [
+        "gemini.totaloutput_optA",
+        "gemini.totalinput",
+        "gemini.fmaout",
+        "gemini.bteout_optA",
+        "gemini.bteout_optB",
+        "gemini.totaloutput_optB"
+        ])
+    optionalMetrics = property(lambda x: [])
+    derivedMetrics = property(lambda x: [])
+

--- a/supremm/plugins/GpuUsage.py
+++ b/supremm/plugins/GpuUsage.py
@@ -9,13 +9,14 @@ class GpuUsage(Plugin):
 
     name = property(lambda x: "gpu")
     mode = property(lambda x: "all")
-    requiredMetrics = property(lambda x: ["nvidia.gpuactive", "nvidia.memused", "nvidia.memactive"])
-    optionalMetrics = property(lambda x: [])
+    requiredMetrics = property(lambda x: ["nvidia.gpuactive", "nvidia.memused"])
+    optionalMetrics = property(lambda x: ["nvidia.memactive"])
     derivedMetrics = property(lambda x: [])
 
     def __init__(self, job):
         super(GpuUsage, self).__init__(job)
         self._data = {}
+        self.statnames = None
 
     def process(self, nodemeta, timestamp, data, description):
 
@@ -24,13 +25,19 @@ class GpuUsage(Plugin):
             return False
 
         if nodemeta.nodename not in self._data:
+            if self.statnames == None:
+                self.statnames = ['gpuactive', 'memused']
+                if len(data) == 3:
+                    self.statnames.append('memactive')
+
             self._data[nodemeta.nodename] = {}
-            self._data[nodemeta.nodename] = {'gpuactive': RollingStats(), 'memused': RollingStats(), 'memactive': RollingStats()}
+            for statname in self.statnames:
+                self._data[nodemeta.nodename][statname] = RollingStats()
+
             self._data[nodemeta.nodename]['names'] = [x for x in description[0][1]]
 
-        self._data[nodemeta.nodename]['gpuactive'].append(1.0 * data[0])
-        self._data[nodemeta.nodename]['memused'].append(1.0 * data[1])
-        self._data[nodemeta.nodename]['memactive'].append(1.0 * data[2])
+        for idx, statname in enumerate(self.statnames):
+            self._data[nodemeta.nodename][statname].append(1.0 * data[idx])
 
         return True
 
@@ -40,9 +47,13 @@ class GpuUsage(Plugin):
         for data in self._data.itervalues():
             for i, devicename in enumerate(data['names']):
                 if devicename not in result:
-                    result[devicename] = {'gpuactive': [], 'memused': [], 'memactive': []}
-                for statname in ['gpuactive', 'memused', 'memactive']:
+                    result[devicename] = {}
+                    for statname in self.statnames:
+                        result[devicename][statname] = []
+                        result[devicename][statname + "max"] = []
+                for statname in self.statnames:
                     result[devicename][statname].append(data[statname].mean()[i])
+                    result[devicename][statname + "max"].append(data[statname].max[i])
             
         output = {}
         for device, data in result.iteritems():

--- a/supremm/plugins/Network.py
+++ b/supremm/plugins/Network.py
@@ -8,11 +8,12 @@ class Network(DeviceBasedPlugin):
     name = property(lambda x: "network")
     requiredMetrics = property(lambda x: [
         "network.interface.in.bytes",
-        "network.interface.in.packets",
         "network.interface.out.bytes",
+        ])
+    optionalMetrics = property(lambda x: [
+        "network.interface.in.packets"
         "network.interface.out.packets"
         ])
-    optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
 

--- a/supremm/plugins/NodeMemoryUsage.py
+++ b/supremm/plugins/NodeMemoryUsage.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+""" Memory usage plugin """
+
+from supremm.plugin import Plugin
+from supremm.statistics import RollingStats, calculate_stats
+from supremm.errors import ProcessingError
+
+class NodeMemoryUsage(Plugin):
+    """ Compute the overall memory usage for a job """
+
+    name = property(lambda x: "nodememory")
+    mode = property(lambda x: "all")
+    requiredMetrics = property(lambda x: ["mem.freemem", "mem.physmem"])
+    optionalMetrics = property(lambda x: [])
+    derivedMetrics = property(lambda x: [])
+
+    def __init__(self, job):
+        super(NodeMemoryUsage, self).__init__(job)
+        self._data = {}
+
+    def process(self, nodemeta, timestamp, data, description):
+        """ Memory statistics are the aritmetic mean of all values except the
+            first and last rather than storing all of the memory measurements for
+            the job, we use the RollingStats() class to keep track of the mean
+            values. Since we don't know which data point is the last one, we update
+            the RollingStats with the value from the previous timestep at each timestep.
+        """
+
+        if nodemeta.nodeindex not in self._data:
+            self._data[nodemeta.nodeindex] = {'freeval': None,
+                                              'free': RollingStats(),
+                                              'physmem': None}
+            return True
+
+        hdata = self._data[nodemeta.nodeindex]
+
+        if hdata['freeval'] != None:
+            hdata['free'].append(hdata['freeval'])
+
+        if len(data[0]) > 0:
+            hdata['freeval'] = data[0][0]
+
+        if hdata['physmem'] == None and len(data[1]) > 0:
+            hdata['physmem'] = data[1][0]
+
+        return True
+
+    def results(self):
+
+        memused = []
+        maxmemused = []
+        memfree = []
+        maxmemfree = []
+
+        for hostidx, memdata in self._data.iteritems():
+            if memdata['free'].count() > 0:
+                memfree.append(memdata['free'].mean())
+                maxmemfree.append(memdata['free'].max)
+
+                if memdata['physmem'] != None:
+                    memused.append(memdata['physmem'] - memdata['free'].mean())
+                    maxmemused.append(memdata['physmem'] - memdata['free'].min)
+
+        if len(memused) == 0:
+            return {"error": ProcessingError.INSUFFICIENT_DATA}
+
+        return {"used": calculate_stats(memused),
+                "maxused": calculate_stats(maxmemused),
+                "free": calculate_stats(memfree),
+                "maxfree": calculate_stats(maxmemfree)}
+

--- a/supremm/plugins/NumaMemoryUsage.py
+++ b/supremm/plugins/NumaMemoryUsage.py
@@ -5,7 +5,7 @@ from supremm.plugin import Plugin
 from supremm.statistics import RollingStats, calculate_stats
 from supremm.errors import ProcessingError
 
-class MemoryUsage(Plugin):
+class NumaMemoryUsage(Plugin):
     """ Compute the overall memory usage for a job """
 
     name = property(lambda x: "memory")
@@ -15,7 +15,7 @@ class MemoryUsage(Plugin):
     derivedMetrics = property(lambda x: [])
 
     def __init__(self, job):
-        super(MemoryUsage, self).__init__(job)
+        super(NumaMemoryUsage, self).__init__(job)
         self._data = {}
         self._hostcpucounts = {}
 

--- a/supremm/plugins/UncoreCounters.py
+++ b/supremm/plugins/UncoreCounters.py
@@ -18,12 +18,14 @@ SNB_METRICS = ["perfevent.hwcounters.snbep_unc_imc0__UNC_M_CAS_COUNT_RD.value",
 NHM_METRICS = ["perfevent.hwcounters.UNC_LLC_MISS_READ.value",
                "perfevent.hwcounters.UNC_LLC_MISS_WRITE.value"]
 
+INTERLAGOS_METRICS = ["perfevent.hwcounters.L3_CACHE_MISSES_ALL.value"]
+
 class UncoreCounters(Plugin):
     """ Compute various uncore performance counter derived metrics """
 
     name = property(lambda x: "uncperf")
     mode = property(lambda x: "firstlast")
-    requiredMetrics = property(lambda x: [SNB_METRICS, NHM_METRICS])
+    requiredMetrics = property(lambda x: [SNB_METRICS, NHM_METRICS, INTERLAGOS_METRICS])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 


### PR DESCRIPTION
Timeseries Metrics:
- Added Clock Ticks timeseries
- Added AMD metrics to SIMD timeseries

Summary Metrics:
- Updated hardware-counter plugins to support AMD counters.
- Allow GPU plugin to run without mem active metric.
- Allow network metrics to only have bytes and not packets.
- Added node-level memory usage plugin; renamed memory usage to numa to
  reduce potential confusion between the two plugins

Preprocessors:
- Update hardware inventory preproc.

The schema version is updated to reflect the new metrics.