### PR TITLE
Fix code that causes deprecation warnings.

### DIFF
--- a/supremm/plugins/ClksTimeseries.py
+++ b/supremm/plugins/ClksTimeseries.py
@@ -111,7 +111,7 @@ class ClksTimeseries(Plugin):
 
             for devid in self._hostdevnames[hostidx].iterkeys():
                 dpnts = len(values[hostidx, :, 0])
-                retdata['hosts'][str(hostidx)]['dev'][devid] = (numpy.diff(self._hostdata[hostidx][:dpnts, devid]) / numpy.diff(values[hostidx, :, 0])).tolist()
+                retdata['hosts'][str(hostidx)]['dev'][devid] = (numpy.diff(self._hostdata[hostidx][:dpnts, int(devid)]) / numpy.diff(values[hostidx, :, 0])).tolist()
 
             retdata['hosts'][str(hostidx)]['names'] = self._hostdevnames[hostidx]
 

--- a/supremm/plugins/CpuUserTimeseries.py
+++ b/supremm/plugins/CpuUserTimeseries.py
@@ -109,7 +109,7 @@ class CpuUserTimeseries(Plugin):
 
             for devid in self._hostdevnames[hostidx].iterkeys():
                 dpnts = len(values[hostidx, :, 0])
-                retdata['hosts'][str(hostidx)]['dev'][devid] = (numpy.diff(self._hostdata[hostidx][:dpnts, devid]) / numpy.diff(values[hostidx, :, 0])).tolist()
+                retdata['hosts'][str(hostidx)]['dev'][devid] = (numpy.diff(self._hostdata[hostidx][:dpnts, int(devid)]) / numpy.diff(values[hostidx, :, 0])).tolist()
 
             retdata['hosts'][str(hostidx)]['names'] = self._hostdevnames[hostidx]
 

--- a/supremm/plugins/SimdInsTimeseries.py
+++ b/supremm/plugins/SimdInsTimeseries.py
@@ -121,7 +121,7 @@ class SimdInsTimeseries(Plugin):
 
             for devid in self._hostdevnames[hostidx].iterkeys():
                 dpnts = len(values[hostidx, :, 0])
-                retdata['hosts'][str(hostidx)]['dev'][devid] = (numpy.diff(self._hostdata[hostidx][:dpnts, devid]) / numpy.diff(values[hostidx, :, 0])).tolist()
+                retdata['hosts'][str(hostidx)]['dev'][devid] = (numpy.diff(self._hostdata[hostidx][:dpnts, int(devid)]) / numpy.diff(values[hostidx, :, 0])).tolist()
 
             retdata['hosts'][str(hostidx)]['names'] = self._hostdevnames[hostidx]
 

--- a/supremm/subsample.py
+++ b/supremm/subsample.py
@@ -13,7 +13,7 @@ class TimeseriesAccumulator(object):
         self._samplewindow = None
         self._leadout = None
         self._data = numpy.empty((nhosts, TimeseriesAccumulator.MAX_DATAPOINTS, 2))
-        self._count = numpy.zeros(nhosts)
+        self._count = numpy.zeros(nhosts, dtype=int)
 
     def adddata(self, hostidx, timestamp, value):
         """ Add a datapoint to the collection.


### PR DESCRIPTION
Recent versions of numpy complain if you don't use int indexes. This
change ensures that all indexes are cast to the correct type before
use.