### PR TITLE
Reduce default number of datapoints in timeseries data.

### DIFF
--- a/supremm/subsample.py
+++ b/supremm/subsample.py
@@ -5,7 +5,7 @@ import numpy
 
 class TimeseriesAccumulator(object):
     """ Stores a subset of time-value pairs for a dataseries """
-    MAX_DATAPOINTS = 100
+    MAX_DATAPOINTS = 50
     LEAD_IN_DATAPOINTS = 10
 
     def __init__(self, nhosts, totaltime):


### PR DESCRIPTION
Change default number of datapoints from 100 to 50 so that the timeseries data is smaller. With 100
datapoints the data size could exceed the MongoDB document size limit of 16MiB if the compute
nodes had 32 cores per node or more.