### PR TITLE
Now use preprocessor to check the perfevent active flag.

### DIFF
--- a/supremm/plugins/Catastrophe.py
+++ b/supremm/plugins/Catastrophe.py
@@ -10,9 +10,9 @@ class Catastrophe(Plugin):
 
     name = property(lambda x: "catastrophe")
     mode = property(lambda x: "all")
-    requiredMetrics = property(lambda x: [["perfevent.hwcounters.MEM_LOAD_RETIRED_L1D_HIT.value", "perfevent.active"], 
-                                          ["perfevent.hwcounters.L1D_REPLACEMENT.value", "perfevent.active"],
-                                          ["perfevent.hwcounters.DATA_CACHE_MISSES_DC_MISS_STREAMING_STORE.value", "perfevent.active"]])
+    requiredMetrics = property(lambda x: [["perfevent.hwcounters.MEM_LOAD_RETIRED_L1D_HIT.value"],
+                                          ["perfevent.hwcounters.L1D_REPLACEMENT.value"],
+                                          ["perfevent.hwcounters.DATA_CACHE_MISSES_DC_MISS_STREAMING_STORE.value"]])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
@@ -23,7 +23,7 @@ class Catastrophe(Plugin):
 
     def process(self, nodemeta, timestamp, data, description):
 
-        if len(data[1]) > 0 and data[1][0] == 0:
+        if self._job.getdata('perf')['active'] != True:
             self._error = ProcessingError.RAW_COUNTER_UNAVAILABLE
             return False
 

--- a/supremm/plugins/CpuPerfCounters.py
+++ b/supremm/plugins/CpuPerfCounters.py
@@ -43,6 +43,10 @@ class CpuPerfCounters(Plugin):
 
     def process(self, nodemeta, timestamp, data, description):
 
+        if self._job.getdata('perf')['active'] != True:
+            self._error = ProcessingError.RAW_COUNTER_UNAVAILABLE
+            return False
+
         ndata = numpy.array(data)
 
         if nodemeta.nodename not in self._first:

--- a/supremm/plugins/MemBwTimeseries.py
+++ b/supremm/plugins/MemBwTimeseries.py
@@ -12,8 +12,7 @@ if python_version.startswith("2.6"):
 else:
     from collections import Counter
 
-SNB_METRICS = ["perfevent.active",
-               "perfevent.hwcounters.snbep_unc_imc0__UNC_M_CAS_COUNT_RD.value",
+SNB_METRICS = ["perfevent.hwcounters.snbep_unc_imc0__UNC_M_CAS_COUNT_RD.value",
                "perfevent.hwcounters.snbep_unc_imc0__UNC_M_CAS_COUNT_WR.value",
                "perfevent.hwcounters.snbep_unc_imc1__UNC_M_CAS_COUNT_RD.value",
                "perfevent.hwcounters.snbep_unc_imc1__UNC_M_CAS_COUNT_WR.value",
@@ -22,8 +21,7 @@ SNB_METRICS = ["perfevent.active",
                "perfevent.hwcounters.snbep_unc_imc3__UNC_M_CAS_COUNT_RD.value",
                "perfevent.hwcounters.snbep_unc_imc3__UNC_M_CAS_COUNT_WR.value"]
 
-NHM_METRICS = ["perfevent.active",
-               "perfevent.hwcounters.UNC_LLC_MISS_READ.value",
+NHM_METRICS = ["perfevent.hwcounters.UNC_LLC_MISS_READ.value",
                "perfevent.hwcounters.UNC_LLC_MISS_WRITE.value"]
 
 class MemBwTimeseries(Plugin):
@@ -44,22 +42,21 @@ class MemBwTimeseries(Plugin):
 
     def process(self, nodemeta, timestamp, data, description):
 
-        if len(data[0]) > 0 and data[0][0] == 0:
-            # If active == 0 then the PMDA was switched off due to user request
+        if self._job.getdata('perf')['active'] != True:
             self._error = ProcessingError.RAW_COUNTER_UNAVAILABLE
             return False
 
-        if len(data[1]) == 0:
+        if len(data[0]) == 0:
             # Ignore timesteps where data was not available
             return True
 
         hostidx = nodemeta.nodeindex
 
         if nodemeta.nodeindex not in self._hostdata:
-            self._hostdata[hostidx] = numpy.empty((TimeseriesAccumulator.MAX_DATAPOINTS, len(data[1])))
-            self._hostdevnames[hostidx] = dict((str(k), v) for k, v in zip(description[1][0], description[1][1]))
+            self._hostdata[hostidx] = numpy.empty((TimeseriesAccumulator.MAX_DATAPOINTS, len(data[0])))
+            self._hostdevnames[hostidx] = dict((str(k), v) for k, v in zip(description[0][0], description[0][1]))
 
-        membw = 64.0 * numpy.sum(data[1:]) / 1024.0 / 1024.0 / 1024.0
+        membw = 64.0 * numpy.sum(data[0:]) / 1024.0 / 1024.0 / 1024.0
 
         insertat = self._data.adddata(hostidx, timestamp, membw)
         if insertat != None:

--- a/supremm/plugins/SimdInsTimeseries.py
+++ b/supremm/plugins/SimdInsTimeseries.py
@@ -12,18 +12,15 @@ if python_version.startswith("2.6"):
 else:
     from collections import Counter
 
-SNB_METRICS = ["perfevent.active",
-               "perfevent.hwcounters.SIMD_FP_256_PACKED_DOUBLE.value",
+SNB_METRICS = ["perfevent.hwcounters.SIMD_FP_256_PACKED_DOUBLE.value",
                "perfevent.hwcounters.FP_COMP_OPS_EXE_SSE_SCALAR_DOUBLE.value",
                "perfevent.hwcounters.FP_COMP_OPS_EXE_SSE_FP_PACKED_DOUBLE.value",
                "perfevent.hwcounters.SIMD_FP_256_PACKED_DOUBLE.value",
                "perfevent.hwcounters.FP_COMP_OPS_EXE_X87.value"]
 
-NHM_METRICS = ["perfevent.active",
-               "perfevent.hwcounters.FP_COMP_OPS_EXE_SSE_FP.value"]
+NHM_METRICS = ["perfevent.hwcounters.FP_COMP_OPS_EXE_SSE_FP.value"]
 
-INTERLAGOS_METRICS = ["perfevent.active",
-                      "perfevent.hwcounters.RETIRED_SSE_OPS_ALL.value"]
+INTERLAGOS_METRICS = ["perfevent.hwcounters.RETIRED_SSE_OPS_ALL.value"]
 
 class SimdInsTimeseries(Plugin):
     """ Generate the CPU usage as a timeseries data """
@@ -43,25 +40,24 @@ class SimdInsTimeseries(Plugin):
 
     def process(self, nodemeta, timestamp, data, description):
 
-        if len(data[0]) > 0 and data[0][0] == 0:
-            # If active == 0 then the PMDA was switched off due to user request
+        if self._job.getdata('perf')['active'] != True:
             self._error = ProcessingError.RAW_COUNTER_UNAVAILABLE
             return False
 
-        if len(data[1]) == 0:
+        if len(data[0]) == 0:
             # Ignore timesteps where data was not available
             return True
 
         hostidx = nodemeta.nodeindex
 
         if nodemeta.nodeindex not in self._hostdata:
-            self._hostdata[hostidx] = numpy.empty((TimeseriesAccumulator.MAX_DATAPOINTS, len(data[1])))
-            self._hostdevnames[hostidx] = dict((str(k), v) for k, v in zip(description[1][0], description[1][1]))
+            self._hostdata[hostidx] = numpy.empty((TimeseriesAccumulator.MAX_DATAPOINTS, len(data[0])))
+            self._hostdevnames[hostidx] = dict((str(k), v) for k, v in zip(description[0][0], description[0][1]))
 
         if len(data) == len(NHM_METRICS): # Note that INTERLAGOS is covered here too
-            flops = numpy.array(data[1])
+            flops = numpy.array(data[0])
         else:
-            flops = 4.0 * data[1] + 2.0 * data[2] + data[3] + data[4]
+            flops = 4.0 * data[0] + 2.0 * data[1] + data[2] + data[3]
 
         insertat = self._data.adddata(hostidx, timestamp, numpy.sum(flops))
         if insertat != None:

--- a/supremm/plugins/UncoreCounters.py
+++ b/supremm/plugins/UncoreCounters.py
@@ -36,6 +36,11 @@ class UncoreCounters(Plugin):
         self._error = None
 
     def process(self, nodemeta, timestamp, data, description):
+
+        if self._job.getdata('perf')['active'] != True:
+            self._error = ProcessingError.RAW_COUNTER_UNAVAILABLE
+            return False
+
         ndata = numpy.array(data)
 
         if nodemeta.nodename not in self._first:

--- a/supremm/preprocessors/PerfEvent.py
+++ b/supremm/preprocessors/PerfEvent.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+""" performance counters pre-processor """
+
+from supremm.plugin import PreProcessor
+
+class PerfEvent(PreProcessor):
+    """ The hardware performance counters are only valid if they were
+        active and counting for the whole job. This preproc checks the active
+        flag at all timepoints and the result is avaiable to all the plugins that
+        use hardware counters.
+    """
+
+    name = property(lambda x: "perf")
+    mode = property(lambda x: "timeseries")
+    requiredMetrics = property(lambda x: ["perfevent.active"])
+    optionalMetrics = property(lambda x: [])
+    derivedMetrics = property(lambda x: [])
+
+    def __init__(self, job):
+        super(PerfEvent, self).__init__(job)
+        self.perfactive = None
+
+    def hoststart(self, hostname):
+        pass
+
+    def process(self, timestamp, data, description):
+
+        if self.perfactive == False:
+            return False
+
+        if len(data) == 1 and data[0][:, 0].size > 0:
+            self.perfactive = data[0][0, 0] != 0
+            return self.perfactive
+
+        return True
+
+    def hostend(self):
+        self._job.adddata(self.name, {"active": self.perfactive})
+
+    def results(self):
+        return None
+


### PR DESCRIPTION
The preprocessor checks the perfevent active flag rather than
having to d it redundantly for each plugin. Also the plugins that
only need the first and last values can retrieve the active status
for the whole job.