### PR TITLE
Fix output issue for first-last type plugins.

### DIFF
--- a/supremm/summarize.py
+++ b/supremm/summarize.py
@@ -400,6 +400,7 @@ class Summarize(object):
             firstimestamp = copy.deepcopy(result.contents.timestamp)
 
             if False == self.runcallback(analytic, result, mtypes, ctx, mdata, metric_id_array):
+                analytic.status = "failure"
                 ctx.pmFreeResult(result)
                 return
 


### PR DESCRIPTION
If a first-last plugin returned false on the first callback, then it would be
incorrectly marked as uninitialized rather than failed. Hence the plugin output
(which should be a valid error code) would not appear in the summary record.