### PR TITLE
Add the pypmlogextract module

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -49,6 +49,8 @@ include supremm/plugins/TaccUncoreCounters.py
 include supremm/plugins/__init__.py
 include supremm/preprocessors/__init__.py
 include supremm/preprocessors/SlurmProc.py
+include supremm/pypmlogextract/dlsymdefs.pxd
+include supremm/pypmlogextract/pypmlogextract.pyx
 include config/config.json
 include config/templates/slurm/slurm-epilog
 include config/templates/slurm/slurm-prolog

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_rpm]
 release = 1%{?dist}
 build_requires = python-devel pcp-libs-devel
-requires = python-pymongo numpy scipy MySQL-python python-pcp pcp %{?el6:python-backport_collections}
+requires = python-pymongo numpy scipy MySQL-python python-pcp pcp Cython %{?el6:python-backport_collections}
 install_script = .rpm_install_script.txt

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """ setup script for SUPReMM job summarization utilities """
 from distutils.core import setup, Extension
+from Cython.Distutils import build_ext
 import sys
 import os
 
@@ -46,8 +47,10 @@ setup(name='supremm',
                'supremm/ingest_jobscripts.py'],
       requires=['numpy',
                 'MySQLdb',
-                'pcp'],
-      ext_modules=[Extension('supremm.pcpfast.libpcpfast', ['supremm/pcpfast/pcpfast.c'], libraries=['pcp'])]
+                'pcp',
+                'Cython'],
+      cmdclass = {'build_ext': build_ext},
+      ext_modules=[Extension('supremm.pcpfast.libpcpfast', ['supremm/pcpfast/pcpfast.c'], libraries=['pcp']), Extension("supremm.pypmlogextract", ["supremm/pypmlogextract/pypmlogextract.pyx"])]
      )
 
 if IS_RPM_BUILD:

--- a/supremm/pypmlogextract/dlsymdefs.pxd
+++ b/supremm/pypmlogextract/dlsymdefs.pxd
@@ -1,0 +1,19 @@
+cdef extern from *:
+    ctypedef char const_char "const char"
+
+cdef extern from 'dlfcn.h' nogil:
+    void* dlopen(const_char *filename, int flag)
+    char *dlerror()
+    void *dlsym(void *handle, const_char *symbol)
+    int dlclose(void *handle)
+
+    unsigned int RTLD_LAZY
+    unsigned int RTLD_NOW
+    unsigned int RTLD_GLOBAL
+    unsigned int RTLD_LOCAL
+    unsigned int RTLD_NODELETE
+    unsigned int RTLD_NOLOAD
+    unsigned int RTLD_DEEPBIND
+
+    unsigned int RTLD_DEFAULT
+    long unsigned int RTLD_NEXT

--- a/supremm/pypmlogextract/pypmlogextract.pyx
+++ b/supremm/pypmlogextract/pypmlogextract.pyx
@@ -1,0 +1,37 @@
+cimport dlsymdefs
+
+from libc.stdlib cimport malloc, free
+from cpython.string cimport PyString_AsString
+
+cdef char ** to_cstring_array(list_str):
+    cdef char **ret = <char **>malloc(len(list_str) * sizeof(char *))
+    for i in xrange(len(list_str)):
+        ret[i] = PyString_AsString(list_str[i])
+    return ret
+
+def pypmlogextract(args):
+
+    cdef void *handle = dlsymdefs.dlopen("libpcp_pmlogextract.so.1",dlsymdefs.RTLD_LAZY)
+    
+    if handle == NULL:
+        print dlsymdefs.dlerror()
+        return 1
+    
+    cdef void *mainFunc = dlsymdefs.dlsym(handle, "mainFunc")
+    if mainFunc == NULL:
+        print dlsymdefs.dlerror()
+        return 1
+    
+    args.insert(0, "pypmlogextract")
+
+    cdef char **myargv = to_cstring_array(args)
+    cdef int myargc = len(args)
+    
+    cdef int retval = (<int (*)(int, char**)> mainFunc)(myargc, myargv)
+
+    # PyString_AsString returns a ref to an internal buffer that shouldn't be freed per the docs
+    # Just free our malloc
+    free(myargv)
+    dlsymdefs.dlclose(handle)
+
+    return retval


### PR DESCRIPTION
Calling fork from an MPI process causes spurious segfaults. Implement
a cython extension that will call a dynamic library version of
pmlogextract.