### PR TITLE
Master/Worker mode for summarize_mpi.py

### DIFF
--- a/supremm/pcparchive.py
+++ b/supremm/pcparchive.py
@@ -13,7 +13,7 @@ import time
 from pcp import pmapi
 import cpmapi as c_pmapi
 
-import pypmlogextract
+from supremm import pypmlogextract
 
 def get_datetime_from_timeval(tv):
     """

--- a/supremm/pcparchive.py
+++ b/supremm/pcparchive.py
@@ -8,9 +8,12 @@ import os
 import shutil
 import subprocess
 import math
+import time
 
 from pcp import pmapi
 import cpmapi as c_pmapi
+
+import pypmlogextract
 
 def get_datetime_from_timeval(tv):
     """
@@ -62,14 +65,29 @@ def get_datetime_from_pmResult(result):
     """
     return get_datetime_from_timeval(result.contents.timestamp)
 
-def extract_and_merge_logs(job, conf, resconf):
+def extract_and_merge_logs(job, conf, resconf, opts):
     """ merge all of the raw pcp archives into one archive per node for each
         node in the job """
 
     adjust_job_start_end(job)
 
-    return pmlogextract(job, conf, resconf)
+    return pmlogextract(job, conf, resconf, opts)
 
+
+def getlibextractcmdline(startdate, enddate, inputarchives, outputarchive):
+    """ build the pmlogextract commmandline """
+
+    # The time format used by the archive merging tool.
+    pcp_time_format = "@ %Y-%m-%d %H:%M:%S UTC"
+
+    cmdline = ["-S", startdate.strftime(pcp_time_format),
+               "-T", enddate.strftime(pcp_time_format)]
+
+    cmdline.extend(inputarchives)
+
+    cmdline.append(outputarchive)
+
+    return cmdline
 
 def getextractcmdline(startdate, enddate, inputarchives, outputarchive):
     """ build the pmlogextract commmandline """
@@ -107,7 +125,7 @@ def genoutputdir(job, conf, resconf):
 
     return jobdir
 
-def pmlogextract(job, conf, resconf):
+def pmlogextract(job, conf, resconf, opts):
     """
     Takes a job description and merges logs for the time it ran.
 
@@ -148,24 +166,35 @@ def pmlogextract(job, conf, resconf):
 
         # Merge the job logs for the node.
         node_archive = os.path.join(jobdir, nodename)
-        pcp_cmd = getextractcmdline(job.getnodebegin(nodename), job.getnodeend(nodename), nodearchives, node_archive)
 
-        logging.debug("Calling %s", " ".join(pcp_cmd))
-        proc = subprocess.Popen(pcp_cmd, stderr=subprocess.PIPE)
-
-        (_, errdata) = proc.communicate()
-
-        if errdata != None and len(errdata) > 0:
-            logging.warning(errdata)
-            job.record_error(errdata)
-
-        if proc.returncode:
-            errmsg = "pmlogextract return code: %s source command was: %s" % (proc.returncode, " ".join(pcp_cmd))
-            logging.warning(errmsg)
-            node_error -= 1
-            job.record_error(errmsg)
+        # Call the library version of pmlogextract to avoid fork calls in MPI
+        if opts['libextract']:
+            pcp_cmd = getlibextractcmdline(job.getnodebegin(nodename), job.getnodeend(nodename), nodearchives, node_archive)
+            logging.debug("Calling pypmlogextract.pypmlogextract(%s)", " ".join(pcp_cmd))
+            node_error = pypmlogextract.pypmlogextract(pcp_cmd)
+            if node_error == 0:
+                job.addnodearchive(nodename, node_archive)
+            else:
+                errdata="pypmlogextract.pypmlogextract(%s) FAILED" % " ".join(pcp_cmd)
+                logging.warning(errdata)
+                job.record_error(errdata)
         else:
-            job.addnodearchive(nodename, node_archive)
+            pcp_cmd = getextractcmdline(job.getnodebegin(nodename), job.getnodeend(nodename), nodearchives, node_archive)
+
+            logging.debug("Calling %s", " ".join(pcp_cmd))
+            proc = subprocess.Popen(pcp_cmd, stderr=subprocess.PIPE)
+            (_, errdata) = proc.communicate()
+
+            if errdata != None and len(errdata) > 0:
+                logging.warning(errdata)
+                job.record_error(errdata)
+
+            if proc.returncode:
+                errmsg = "pmlogextract return code: %s source command was: %s" % (proc.returncode, " ".join(pcp_cmd))
+                logging.warning(errmsg)
+                node_error -= 1
+                job.record_error(errmsg)
+            else:
+                job.addnodearchive(nodename, node_archive)
 
     return node_error
-

--- a/supremm/summarize_jobs.py
+++ b/supremm/summarize_jobs.py
@@ -42,6 +42,7 @@ def usage():
     print "  -t --tag              tag to add to the summarization field in mongo"
     print "  -D --delete T|F       whether to delete job-level archives after processing."
     print "  -E --extract-only     only extract the job-level archives (sets delete=False)"
+    print "  -L --use-lib-extract  use libpcp_pmlogextract.so.1 instead of pmlogextract"
     print "  -o --output DIR       override the output directory for the job archives."
     print "                        This directory will be emptied before used and no"
     print "                        subdirectories will be created. This option is ignored "
@@ -63,6 +64,7 @@ def getoptions():
         "threads": 1,
         "dodelete": True,
         "extractonly": False,
+        "libextract": False,
         "job_output_dir": None,
         "tag": None,
         "force_timeout": 2 * 24 * 3600,
@@ -81,6 +83,7 @@ def getoptions():
                       "tag=",
                       "delete=", 
                       "extract-only", 
+                      "use-lib-extract",
                       "output=", 
                       "help"])
 
@@ -99,6 +102,8 @@ def getoptions():
             starttime = parsetime(opt[1])
         if opt[0] in ("-e", "--end"):
             endtime = parsetime(opt[1])
+        if opt[0] in ("-L", "--use-lib-extract"):
+            retdata['libextract'] = True
         if opt[0] in ("-T", "--timeout"):
             retdata['force_timeout'] = int(opt[1])
         if opt[0] in ("-t", "--tag"):
@@ -147,7 +152,7 @@ def summarizejob(job, conf, resconf, plugins, preprocs, m, dblog, opts):
 
     try:
         mergestart = time.time()
-        mergeresult = extract_and_merge_logs(job, conf, resconf)
+        mergeresult = extract_and_merge_logs(job, conf, resconf, opts)
         mergeend = time.time()
 
         if opts['extractonly']: 

--- a/supremm/summarize_mpi.py
+++ b/supremm/summarize_mpi.py
@@ -310,9 +310,6 @@ def main():
     # For MPI jobs, do something sane with logging.
     setuplogger(logging.ERROR, logout, opts['log'])
 
-    if sys.version.startswith("2.7"):
-        logging.captureWarnings(True)
-
     config = Config()
 
     if comm.Get_size() < 2:

--- a/supremm/summarize_mpi.py
+++ b/supremm/summarize_mpi.py
@@ -3,6 +3,8 @@
     Main script for converting host-based pcp archives to job-level summaries.
 """
 
+from mpi4py import MPI
+
 import logging
 from supremm.config import Config
 from supremm.account import DbAcct
@@ -12,6 +14,7 @@ from supremm import outputter
 from supremm.summarize import Summarize
 from supremm.plugin import loadplugins, loadpreprocessors
 from supremm.scripthelpers import parsetime
+from supremm.scripthelpers import setuplogger
 
 import sys
 import os
@@ -20,7 +23,6 @@ import traceback
 import time
 import datetime
 import shutil
-from mpi4py import MPI
 
 
 def usage():
@@ -42,6 +44,7 @@ def usage():
     print "  -t --tag              tag to add to the summarization field in mongo"
     print "  -D --delete T|F       whether to delete job-level archives after processing."
     print "  -E --extract-only     only extract the job-level archives (sets delete=False)"
+    print "  -L --use-lib-extract  use libpcp_pmlogextract.so.1 instead of pmlogextract"
     print "  -o --output DIR       override the output directory for the job archives."
     print "                        This directory will be emptied before used and no"
     print "                        subdirectories will be created. This option is ignored "
@@ -62,6 +65,7 @@ def getoptions():
         "log": logging.INFO,
         "dodelete": True,
         "extractonly": False,
+        "libextract": False,
         "newonly": False,
         "job_output_dir": None,
         "tag": None,
@@ -69,7 +73,7 @@ def getoptions():
         "resource": None
     }
 
-    opts, _ = getopt(sys.argv[1:], "j:r:dqs:e:NT:t:D:Eo:h", 
+    opts, _ = getopt(sys.argv[1:], "j:r:dqs:e:LNT:t:D:Eo:h", 
                      ["localjobid=", 
                       "resource=", 
                       "debug", 
@@ -81,6 +85,7 @@ def getoptions():
                       "tag=",
                       "delete=", 
                       "extract-only", 
+                      "use-lib-extract", 
                       "output=", 
                       "help"])
 
@@ -99,6 +104,8 @@ def getoptions():
             endtime = parsetime(opt[1])
         if opt[0] in ("-N", "--new-only"):
             retdata['newonly'] = True
+        if opt[0] in ("-L", "--use-lib-extract"):
+            retdata['libextract'] = True
         if opt[0] in ("-T", "--timeout"):
             retdata['force_timeout'] = int(opt[1])
         if opt[0] in ("-t", "--tag"):
@@ -147,7 +154,7 @@ def summarizejob(job, conf, resconf, plugins, preprocs, m, dblog, opts):
 
     try:
         mergestart = time.time()
-        mergeresult = extract_and_merge_logs(job, conf, resconf)
+        mergeresult = extract_and_merge_logs(job, conf, resconf, opts)
         mergeend = time.time()
 
         if opts['extractonly']: 
@@ -194,8 +201,7 @@ def override_defaults(resconf, opts):
 
     return resconf
 
-
-def processjobs(config, opts, procid):
+def processjobs(config, opts, procid, comm):
     """ main function that does the work. One run of this function per process """
 
     preprocs = loadpreprocessors()
@@ -215,37 +221,107 @@ def processjobs(config, opts, procid):
         with outputter.factory(config, resconf) as m:
 
             if resconf['batch_system'] == "XDMoD":
-                dbif = XDMoDAcct(resconf['resource_id'], config, opts['threads'], procid)
+                dbif = XDMoDAcct(resconf['resource_id'], config, None, None)
             else:
-                dbif = DbAcct(resconf['resource_id'], config, opts['threads'], procid)
+                dbif = DbAcct(resconf['resource_id'], config)
 
-            if opts['mode'] == "single":
-                for job in dbif.getbylocaljobid(opts['local_job_id']):
-                    summarizejob(job, config, resconf, plugins, preprocs, m, dbif, opts)
-            elif opts['mode'] == "timerange":
-                for job in dbif.getbytimerange(opts['start'], opts['end'], opts['newonly']):
-                    summarizejob(job, config, resconf, plugins, preprocs, m, dbif, opts)
+            # Master
+            if procid==0:
+                getjobs={}
+                if opts['mode'] == "single":
+                    getjobs['cmd']=dbif.getbylocaljobid
+                    getjobs['opts']=[opts['local_job_id'],]
+                elif opts['mode'] == "timerange":
+                    getjobs['cmd']=dbif.getbytimerange
+                    getjobs['opts']=[opts['start'], opts['end'], opts['newonly']]
+                else:
+                    getjobs['cmd']=dbif.get
+                    getjobs['opts']=[None, None]
+
+                logging.debug("MASTER STARTING")
+                numworkers = opts['threads']-1
+                numsent = 0
+                numreceived = 0
+
+                for job in getjobs['cmd'](*(getjobs['opts'])):
+                    if numsent >= numworkers:
+                        # Wait for a worker to be done and then send more work
+                        process = comm.recv(source=MPI.ANY_SOURCE, tag=1)
+                        numreceived += 1
+                        comm.send(job, dest=process, tag=1)
+                        numsent += 1
+                        logging.debug("Sent new job: %d sent, %d received", numsent, numreceived)
+                    else:
+                        # Initial batch
+                        comm.send(job, dest=numsent+1, tag=1)
+                        numsent += 1
+                        logging.debug("Initial Batch: %d sent, %d received", numsent, numreceived)
+
+                logging.debug("After all jobs sent: %d sent, %d received", numsent, numreceived)
+
+                # Get leftover results
+                while numsent > numreceived:
+                    comm.recv(source=MPI.ANY_SOURCE, tag=1)
+                    numreceived += 1
+                    logging.debug("Getting leftovers. %d sent, %d received", numsent, numreceived)
+
+                # Shut them down
+                for worker in xrange(numworkers):
+                    logging.debug("Shutting down: %d", worker+1)
+                    comm.send(None, dest=worker+1, tag=1)
+
+            # Worker
             else:
-                for job in dbif.get(None, None):
-                    summarizejob(job, config, resconf, plugins, preprocs, m, dbif, opts)
-
+                logging.debug("WORKER %d STARTING", procid)
+                while True:
+                    recvtries=0
+                    while not comm.Iprobe(source=0, tag=1):
+                        if recvtries < 1000:
+                            recvtries+=1
+                            continue
+                        # Sleep so we can instrument how efficient we are
+                        # Otherwise, workers spin on exit at the hidden mpi_finalize call.
+                        # If you care about maximum performance and don't care about wasted cycles, remove the Iprobe/sleep loop
+                        # Empirically, a tight loop with time.sleep(0.001) uses ~1% CPU
+                        time.sleep(0.001)
+                    job = comm.recv(source=0, tag=1)
+                    if job != None:
+                        logging.debug("Rank: %s, Starting: %s", procid, job.job_id)
+                        summarizejob(job, config, resconf, plugins, preprocs, m, dbif, opts)
+                        logging.debug("Rank: %s, Finished: %s", procid, job.job_id)
+                        comm.send(procid, dest=0, tag=1)
+                    else:
+                        # Got shutdown message
+                        break
 
 def main():
     """
     main entry point for script
     """
+
+    comm = MPI.COMM_WORLD
+
     opts = getoptions()
 
-    logging.basicConfig(format='%(asctime)s [%(levelname)s] %(message)s', datefmt='%Y-%m-%dT%H:%M:%S', level=opts['log'])
+    opts['threads'] = comm.Get_size()
+
+    logout = "mpiOutput-{}.log".format(comm.Get_rank())
+
+    # For MPI jobs, do something sane with logging.
+    setuplogger(logging.ERROR, logout, opts['log'])
+
     if sys.version.startswith("2.7"):
         logging.captureWarnings(True)
 
     config = Config()
 
-    comm = MPI.COMM_WORLD
-    opts['threads'] = comm.Get_size()
+    if comm.Get_size() < 2:
+        logging.error("Must run MPI job with at least 2 processes")
+        sys.exit(1)
 
-    processjobs(config, opts, comm.Get_rank())
+    processjobs(config, opts, comm.Get_rank(), comm)
+
+    logging.debug("Rank: %s FINISHED", comm.Get_rank())
 
 if __name__ == "__main__":
     main()

--- a/supremm/xdmodaccount.py
+++ b/supremm/xdmodaccount.py
@@ -95,7 +95,7 @@ class XDMoDAcct(Accounting):
         if self._nthreads != None and self._threadidx != None:
             query += " AND (CRC32(jf.local_job_id_raw) %% %s) = %s"
             data = data + (self._nthreads, self._threadidx)
-        query += " ORDER BY jf.end_time_ts ASC"
+        query += " ORDER BY jf.nodecount DESC"
 
         for job in  self.executequery(query, data):
             yield job


### PR DESCRIPTION
Allow the tasks to be handed out as nodes finish the previous one.
Should allow for better packing.

Also, include a flag to use a library version of pmlogextract.  Suggest
usage of this when running in MPI mode since forking from an MPI task
has shown to cause segfaults in some MPI implementations.

Change the logging for mpi jobs.  Each task has its own log file. printf
from the dlopened pypmlogextract will not be captured.  That fix is a WIP.