### PR TITLE
Allow plugins to be enabled/disabled per resource

### DIFF
--- a/supremm/summarize_mpi.py
+++ b/supremm/summarize_mpi.py
@@ -232,9 +232,6 @@ def processjobs(config, opts, procid, comm):
     allplugins = loadplugins()
     logging.debug("Loaded %s plugins", len(allplugins))
 
-    print allpreprocs
-    print allplugins
-
     for r, resconf in config.resourceconfigs():
         if opts['resource'] == None or opts['resource'] == r or opts['resource'] == str(resconf['resource_id']):
             logging.info("Processing resource %s", r)

--- a/supremm/summarize_mpi.py
+++ b/supremm/summarize_mpi.py
@@ -207,20 +207,45 @@ def override_defaults(resconf, opts):
 
     return resconf
 
+def filter_plugins(resconf, preprocs, plugins):
+    """ Filter the list of plugins/preprocs to use on a resource basis """
+
+    # Default is to use all
+    filtered_preprocs=preprocs
+    filtered_plugins=plugins
+
+    if "plugin_whitelist" in resconf:
+       filtered_preprocs = [x for x in preprocs if x.__name__ in resconf['plugin_whitelist']]
+       filtered_plugins = [x for x in plugins if x.__name__ in resconf['plugin_whitelist']]
+    elif "plugin_blacklist" in resconf:
+       filtered_preprocs = [x for x in preprocs if x.__name__ not in resconf['plugin_blacklist']]
+       filtered_plugins = [x for x in plugins if x.__name__ not in resconf['plugin_blacklist']]
+
+    return filtered_preprocs, filtered_plugins
+
 def processjobs(config, opts, procid, comm):
     """ main function that does the work. One run of this function per process """
 
-    preprocs = loadpreprocessors()
-    logging.debug("Loaded %s preprocessors", len(preprocs))
+    allpreprocs = loadpreprocessors()
+    logging.debug("Loaded %s preprocessors", len(allpreprocs))
 
-    plugins = loadplugins()
-    logging.debug("Loaded %s plugins", len(plugins))
+    allplugins = loadplugins()
+    logging.debug("Loaded %s plugins", len(allplugins))
+
+    print allpreprocs
+    print allplugins
 
     for r, resconf in config.resourceconfigs():
         if opts['resource'] == None or opts['resource'] == r or opts['resource'] == str(resconf['resource_id']):
             logging.info("Processing resource %s", r)
         else:
             continue
+
+        preprocs, plugins = filter_plugins(resconf, allpreprocs, allplugins)
+
+        logging.debug("Using %s preprocessors", len(preprocs))
+        logging.debug("Using %s plugins", len(plugins))
+
 
         resconf = override_defaults(resconf, opts)
 


### PR DESCRIPTION
Add the following syntax to config.json under the resource section:

"plugin_blacklist" : ["SlurmProc", "Gpfs", "GpfsTimeseries"]

"plugin_whitelist" : ["SlurmProc", "Gpfs", "GpfsTimeseries"]

Only one or the other should be used. Whitelist is highest
priority.  Affects both preprcs and plugins.