### PR TITLE
A few BW specific changes

### DIFF
--- a/supremm/pcparchive.py
+++ b/supremm/pcparchive.py
@@ -52,6 +52,9 @@ def adjust_job_start_end(job):
                 context = pmapi.pmContext(c_pmapi.PM_CONTEXT_ARCHIVE, fname)
                 end = datetime.datetime.utcfromtimestamp(math.ceil(context.pmGetArchiveEnd()))
 
+        # Trim 60 seconds off the job end
+        end = max(job.end_datetime - datetime.timedelta(seconds=60), job.start_datetime)
+
         job.setnodebeginend(nodename, begin, end)
 
 def get_datetime_from_pmResult(result):

--- a/supremm/xdmodaccount.py
+++ b/supremm/xdmodaccount.py
@@ -62,9 +62,7 @@ class XDMoDAcct(Accounting):
                                (j.start_time_ts BETWEEN a.start_time_ts AND a.end_time_ts)
                                OR (j.end_time_ts BETWEEN a.start_time_ts AND a.end_time_ts)
                                OR (j.start_time_ts < a.start_time_ts and j.end_time_ts > a.end_time_ts)
-                               OR (CAST(j.local_job_id_raw AS CHAR) = a.jobid)
                            )
-                           AND (a.jobid = CAST(j.local_job_id_raw AS CHAR) OR a.jobid IS NULL)
                        GROUP BY 1, 2 ORDER BY 1 ASC, a.start_time_ts ASC """
 
         self.dbsettings = config.getsection("datawarehouse")
@@ -128,7 +126,7 @@ class XDMoDAcct(Accounting):
             query += " AND (CRC32(jf.local_job_id_raw) %% %s) = %s"
             data = data + (self._nthreads, self._threadidx)
 
-        query += " ORDER BY jf.nodecount DESC"
+        query += " ORDER BY jf.end_time_ts ASC"
 
         for job in  self.executequery(query, data):
             yield job
@@ -231,7 +229,7 @@ class XDMoDArchiveCache(ArchiveCache):
             logging.debug("Ignoring archive for host %s", hostname)
             return
 
-        query = """INSERT INTO modw_supremm.archive (hostid, filename, start_time_ts, end_time_ts, jobid) 
+        query = """INSERT INTO modw_supremm.archive_staging (hostid, filename, start_time_ts, end_time_ts, jobid) 
                        VALUES( (SELECT id FROM modw.hosts WHERE hostname = %s),%s,%s,%s,%s) 
                        ON DUPLICATE KEY UPDATE start_time_ts=%s, end_time_ts=%s"""
 


### PR DESCRIPTION
Helps to have these in the tree so we don't have to apply a diff each time we reinstall. But
lump them all together to make it easier to revert when merged back into master.

Don't process jobs that would take a really long time, but mark
in the MongDB the reason.  These values probably should be configurable.

Also includes a few BW specific changes:
-trimming the last 60 seconds to deal with counter reset in epilog
-simplifying the job query since we don't have job start/end records

Also, revert the change of job ordering by size.  This caused resource contention during processing.