### PR TITLE
Output configuration supports 'type' as synonym for 'db_engine'

### DIFF
--- a/supremm/outputter.py
+++ b/supremm/outputter.py
@@ -10,6 +10,11 @@ class factory(object):
     def __init__(self, config, resconf):
         outconf = config.getsection("outputdatabase")
 
+        if 'db_engine' not in outconf and 'type' in outconf:
+            # Older versions of the documentation recommended 'type' as the
+            # configuration parameter use this if 'db_engine' is absent
+            outconf['db_engine'] = outconf['type']
+
         if outconf['db_engine'].lower() == "mongodb":
             self._impl = MongoOutput(outconf, resconf)
         elif outconf['db_engine'].lower() == "stdout":

--- a/supremm/supremm-setup
+++ b/supremm/supremm-setup
@@ -80,7 +80,7 @@ def getdirectsettings(display, defaults):
     outconfig = {"datawarehouse": {"db_engine": "MySQLDB",
                                    "host": sqlhost,
                                    "defaultsfile": mycnffilename},
-                 "outputdatabase": {"type": "mongodb",
+                 "outputdatabase": {"db_engine": "mongodb",
                                     "uri": mongouri,
                                     "dbname": mongodbname}}
     mycnf = "[client]\nuser={0}\npassword={1}\n".format(sqluser, sqlpass)


### PR DESCRIPTION
The published documentation (and defaults for the interactive script) both
incorrectly spceified that the database engine setting was 'type', however the
code was expecting to see 'db_engine'. Now support either setting, with db_engine
as the preference.