### PR TITLE
Fix missing timeseries document _id.

### DIFF
--- a/supremm/outputter.py
+++ b/supremm/outputter.py
@@ -118,6 +118,7 @@ class MongoOutput(object):
         summary['summarization'].update(mdata)
 
         if 'timeseries' in summary:
+            summary['timeseries']['_id'] = summary["_id"]
             self._outdb[self._timeseries].update({"_id": summary["_id"]}, summary['timeseries'], upsert=True)
             del summary['timeseries']
 


### PR DESCRIPTION
The _id value for timeseries documents was not stored correctly on Centos 6.8
with the EPEL versions of mongodb 2.4.14. This results in the timeseries
information not being shown in the XDMoD Job Viewer.