### PR TITLE
HardwareInventory: handle missing cpu metrics.

### DIFF
--- a/supremm/preprocessors/HardwareInventory.py
+++ b/supremm/preprocessors/HardwareInventory.py
@@ -41,8 +41,8 @@ class HardwareInventory(PreProcessor):
     def hostend(self):
         if self.corecount != None:
             self.data[self.hostname] = {'cores': self.corecount}
+            self.cores.append(self.corecount)
 
-        self.cores.append(self.corecount)
         self.corecount = None
         self.hostname = None
 


### PR DESCRIPTION
Fix bug in hardware inventory preprocessor that throws an exception
if the cpu metrics are missing.