### PR TITLE
Index archives fix

### DIFF
--- a/supremm/indexarchives.py
+++ b/supremm/indexarchives.py
@@ -182,6 +182,8 @@ class PcpArchiveFinder(object):
             t1 = time.time()
             datdirs = os.listdir(hostdir)
             t2 = time.time()
+            t3 = t2
+            t4 = t2
             for datedir in datdirs:
 
                 yeardirOk = self.ymdok(datedir)


### PR DESCRIPTION
If there were no directories checked in the old format, t4 and t3
were not set. This lead to an exception and no further
processing was done. Hidden by the lack of scoping for loop
variables in python.