### PR TITLE
Added max node time limit and corresponding error message.

### DIFF
--- a/supremm/errors.py
+++ b/supremm/errors.py
@@ -20,7 +20,8 @@ class ProcessingError(object):
     NO_ARCHIVES = 15
     SUMMARIZATION_ERROR = 16
     RAW_ARCHIVES = 17
-    MAX_ERROR = 18
+    JOB_TOO_MANY_NODEHOURS = 18
+    MAX_ERROR = 19
 
     def __init__(self, err_id):
         self._id = err_id
@@ -43,7 +44,8 @@ class ProcessingError(object):
             ProcessingError.UNKNOWN_CANNOT_PROCESS: "Job cannot be summarized for unknown reason",
             ProcessingError.NO_ARCHIVES: "None of the nodes in the job have pcp archives",
             ProcessingError.SUMMARIZATION_ERROR: "There were enough archives to try summarization, but too few archives were successfully processed",
-            ProcessingError.RAW_ARCHIVES: "Not enough raw archives to try pmlogextract"
+            ProcessingError.RAW_ARCHIVES: "Not enough raw archives to try pmlogextract",
+            ProcessingError.JOB_TOO_MANY_NODEHOURS: "Total job node hours exceeded threshold"
         }
         return names[self._id]
 

--- a/supremm/proc_common.py
+++ b/supremm/proc_common.py
@@ -84,6 +84,7 @@ def getoptions(has_mpi):
         "process_big": False,
         "process_error": 0,
         "max_nodes": 0,
+        "max_nodetime": None,
         "min_duration": None,
         "min_parallel_duration": None,
         "max_duration": 864000,
@@ -110,6 +111,7 @@ def getoptions(has_mpi):
                       "process-big",
                       "process-error=",
                       "max-nodes=",
+                      "max-nodetime=",
                       "min-duration=",
                       "min-parallel-duration=",
                       "max-duration=",
@@ -155,6 +157,8 @@ def getoptions(has_mpi):
             retdata['libextract'] = True
         if opt[0] in ("-M", "--max-nodes"):
             retdata['max_nodes'] = int(opt[1])
+        if opt[0] == "--max-nodetime":
+            retdata['max_nodetime'] = int(opt[1])
         if opt[0] == "--min-duration":
             retdata['min_duration'] = int(opt[1])
         if opt[0] == "--min-parallel-duration":
@@ -268,6 +272,12 @@ def summarizejob(job, conf, resconf, plugins, preprocs, m, dblog, opts):
             summarizeerror = ProcessingError.JOB_TOO_BIG
             missingnodes = job.nodecount
             logging.info("Skipping %s, skipped_job_too_big", job.job_id)
+        elif opts['max_nodetime'] != None and (job.nodecount * job.walltime) > opts['max_nodetime']:
+            mergeresult = 1
+            mdata["skipped_job_nodehours"] = True
+            summarizeerror = ProcessingError.JOB_TOO_MANY_NODEHOURS
+            missingnodes = job.nodecount
+            logging.info("Skipping %s, skipped_job_too_big (node time)", job.job_id)
         elif job.walltime >= opts['max_duration']:
             mergeresult = 1
             mdata["skipped_too_long"] = True

--- a/tests/getoptionstest.py
+++ b/tests/getoptionstest.py
@@ -19,6 +19,7 @@ class TestGetOptions(unittest.TestCase):
                 'min_duration': None,
                 'min_parallel_duration': None,
                 'max_duration': 864000,
+                'max_nodetime': None,
                 'mode': 'all',
                 'process_all': False,
                 'process_bad': True,
@@ -166,6 +167,12 @@ class TestGetOptions(unittest.TestCase):
         expected['dump_proclist'] = True
 
         self.helper(['--dump-proclist'], expected)
+
+    def testmaxnodetime(self):
+        expected = self.defaults.copy()
+        expected['max_nodetime'] = 3455
+
+        self.helper(['--max-nodetime', "3455"], expected)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- The maximum node time for a job can now be specified. This causes
  long large jobs to be skipped.
- Also add tests for the new code.