### PR TITLE
Minor bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## [Unreleased]
+## [1.0.3] - 2017-08-01
+
+### Changed
+- Updated text content of indexarchives debug message to clarify meaning of ignored archives.
+
+### Fixed
+- Fix issue with timeseries documents not being saved with the Centos 6 EPEL
+  version of MongoDB (2.4). It is likely that this issue affects newer versions
+  of MongoDB too.
 
 
 ## [1.0.2] - 2017-01-26

--- a/supremm/outputter.py
+++ b/supremm/outputter.py
@@ -118,6 +118,7 @@ class MongoOutput(object):
         summary['summarization'].update(mdata)
 
         if 'timeseries' in summary:
+            summary['timeseries']['_id'] = summary["_id"]
             self._outdb[self._timeseries].update({"_id": summary["_id"]}, summary['timeseries'], upsert=True)
             del summary['timeseries']
 

--- a/supremm/xdmodaccount.py
+++ b/supremm/xdmodaccount.py
@@ -179,7 +179,7 @@ class XDMoDArchiveCache(ArchiveCache):
         """ Insert a job record """
         cur = self.con.cursor()
         if hostname not in self._hostnamecache:
-            logging.debug("Ignoring archive for host %s", hostname)
+            logging.debug("Ignoring archive for host \"%s\" because there are no jobs in the XDMoD datawarehouse that ran on this host.", hostname)
             return
 
         query = """INSERT INTO modw_supremm.archive (hostid, filename, start_time_ts, end_time_ts, jobid) 


### PR DESCRIPTION
- Updated text content of indexarchives debug message to clarify
  meaning of ignored archives.
- Fix issue with timeseries documents not being saved with the Centos 6
  EPEL version of MongoDB (2.4). It is likely that this issue affects
  newer versions of MongoDB too.