### PR TITLE
Update array access for compatibility with numpy 1.12

### DIFF
--- a/supremm/plugins/CpuUserTimeseries.py
+++ b/supremm/plugins/CpuUserTimeseries.py
@@ -109,7 +109,7 @@ class CpuUserTimeseries(Plugin):
 
             for devid in self._hostdevnames[hostidx].iterkeys():
                 dpnts = len(values[hostidx, :, 0])
-                retdata['hosts'][str(hostidx)]['dev'][devid] = (numpy.diff(self._hostdata[hostidx][:dpnts, devid]) / numpy.diff(values[hostidx, :, 0])).tolist()
+                retdata['hosts'][str(hostidx)]['dev'][devid] = (numpy.diff(self._hostdata[hostidx][:dpnts, numpy.int(devid)]) / numpy.diff(values[hostidx, :, 0])).tolist()
 
             retdata['hosts'][str(hostidx)]['names'] = self._hostdevnames[hostidx]
 

--- a/supremm/plugins/MemBwTimeseries.py
+++ b/supremm/plugins/MemBwTimeseries.py
@@ -115,7 +115,7 @@ class MemBwTimeseries(Plugin):
 
             for devid in self._hostdevnames[hostidx].iterkeys():
                 dpnts = len(values[hostidx, :, 0])
-                retdata['hosts'][str(hostidx)]['dev'][devid] = (numpy.diff(self._hostdata[hostidx][:dpnts, devid]) / numpy.diff(values[hostidx, :, 0])).tolist()
+                retdata['hosts'][str(hostidx)]['dev'][devid] = (numpy.diff(self._hostdata[hostidx][:dpnts, numpy.int(devid)]) / numpy.diff(values[hostidx, :, 0])).tolist()
 
             retdata['hosts'][str(hostidx)]['names'] = self._hostdevnames[hostidx]
 

--- a/supremm/plugins/MemUsageTimeseries.py
+++ b/supremm/plugins/MemUsageTimeseries.py
@@ -85,7 +85,7 @@ class MemUsageTimeseries(Plugin):
 
             for devid in self._hostdevnames[hostidx].iterkeys():
                 dpnts = len(values[hostidx, :, 0])
-                retdata['hosts'][str(hostidx)]['dev'][devid] = self._hostdata[hostidx][:dpnts, devid].tolist()
+                retdata['hosts'][str(hostidx)]['dev'][devid] = self._hostdata[hostidx][:dpnts, numpy.int(devid)].tolist()
 
             retdata['hosts'][str(hostidx)]['names'] = self._hostdevnames[hostidx]
 

--- a/supremm/plugins/SimdInsTimeseries.py
+++ b/supremm/plugins/SimdInsTimeseries.py
@@ -114,7 +114,7 @@ class SimdInsTimeseries(Plugin):
 
             for devid in self._hostdevnames[hostidx].iterkeys():
                 dpnts = len(values[hostidx, :, 0])
-                retdata['hosts'][str(hostidx)]['dev'][devid] = (numpy.diff(self._hostdata[hostidx][:dpnts, devid]) / numpy.diff(values[hostidx, :, 0])).tolist()
+                retdata['hosts'][str(hostidx)]['dev'][devid] = (numpy.diff(self._hostdata[hostidx][:dpnts, numpy.int(devid)]) / numpy.diff(values[hostidx, :, 0])).tolist()
 
             retdata['hosts'][str(hostidx)]['names'] = self._hostdevnames[hostidx]
 

--- a/supremm/plugins/TotalMemUsageTimeseries.py
+++ b/supremm/plugins/TotalMemUsageTimeseries.py
@@ -85,7 +85,7 @@ class TotalMemUsageTimeseries(Plugin):
 
             for devid in self._hostdevnames[hostidx].iterkeys():
                 dpnts = len(values[hostidx, :, 0])
-                retdata['hosts'][str(hostidx)]['dev'][devid] = self._hostdata[hostidx][:dpnts, devid].tolist()
+                retdata['hosts'][str(hostidx)]['dev'][devid] = self._hostdata[hostidx][:dpnts, numpy.int(devid)].tolist()
 
             retdata['hosts'][str(hostidx)]['names'] = self._hostdevnames[hostidx]
 

--- a/supremm/subsample.py
+++ b/supremm/subsample.py
@@ -13,7 +13,7 @@ class TimeseriesAccumulator(object):
         self._samplewindow = None
         self._leadout = None
         self._data = numpy.empty((nhosts, TimeseriesAccumulator.MAX_DATAPOINTS, 2))
-        self._count = numpy.zeros(nhosts)
+        self._count = numpy.zeros(nhosts, dtype=int)
 
     def adddata(self, hostidx, timestamp, value):
         """ Add a datapoint to the collection.


### PR DESCRIPTION
Recent numpy versions deprecated using anything apart from a int to index a numpy
array. This change explictly sets the correct data type for the array indexes.