### PR TITLE
Minor fix for metric name mem.numa.util.NFS_Unstable

### DIFF
--- a/config/templates/pmlogger/pmlogger-supremm.config
+++ b/config/templates/pmlogger/pmlogger-supremm.config
@@ -165,7 +165,7 @@ log mandatory on %{standard_freq} {
 	mem.numa.util.inactive_anon
 	mem.numa.util.inactive_file
 	mem.numa.util.mapped
-	mem.numa.util.NFS_unstable
+	mem.numa.util.NFS_Unstable
 	mem.numa.util.pageTables
 	mem.numa.util.slab
 	mem.numa.util.used


### PR DESCRIPTION
This is extremely minor.  The default template would produce a warning.  Only tested in docker test environment.

preprocessor cmd: /usr/libexec/pcp/bin/pmcpp -rs /etc/pcp/pmlogger/pmlogger-supremm.config -I /var/lib/pcp/config/pmlogger
Warning [/etc/pcp/pmlogger/pmlogger-supremm.config, line 168]
Problem with lookup for metric "mem.numa.util.NFS_unstable" ... logging not activated
Reason: Unknown metric name
