### PR TITLE
Sort procs by count

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN yum install -y \
     python2-pip \
     python2-mock \
     python-ctypes \
+    python-psutil \
     python-pcp \
     python-pymongo \
     MySQL-python \


### PR DESCRIPTION
Return the process names ordered by frequency. This typically will result in the parallel processes appearing at the begining of the list and the stage-in and stage-out processes closer to the end.
