### PR TITLE
Add dry-run option to summarize scripts

### DIFF
--- a/src/supremm/summarize_jobs.py
+++ b/src/supremm/summarize_jobs.py
@@ -38,7 +38,7 @@ def processjobs(config, opts, procid):
         logging.debug("Using %s preprocessors", len(preprocs))
         logging.debug("Using %s plugins", len(plugins))
 
-        with outputter.factory(config, resconf) as m:
+        with outputter.factory(config, resconf, dry_run=opts["dry_run"]) as m:
 
             if resconf['batch_system'] == "XDMoD":
                 dbif = XDMoDAcct(resconf['resource_id'], config, opts['threads'], procid)

--- a/src/supremm/summarize_mpi.py
+++ b/src/supremm/summarize_mpi.py
@@ -41,7 +41,7 @@ def processjobs(config, opts, procid, comm):
         logging.debug("Using %s preprocessors", len(preprocs))
         logging.debug("Using %s plugins", len(plugins))
 
-        with outputter.factory(config, resconf) as m:
+        with outputter.factory(config, resconf, dry_run=opts["dry_run"]) as m:
 
             if resconf['batch_system'] == "XDMoD":
                 dbif = XDMoDAcct(resconf['resource_id'], config, None, None)


### PR DESCRIPTION
This option processes data but does not write to any databases (useful
for testing). When the outputter is set to mongo in config.json and
the dry-run flag is set a no-op outputter is used. For non-database
outputters (file or stdout), data is still written.

Uses `-n --dry-run` command line option.

