### PR TITLE
SlurmProc preprocessor performance tuning

### DIFF
--- a/src/supremm/preprocessors/SlurmProc.py
+++ b/src/supremm/preprocessors/SlurmProc.py
@@ -102,7 +102,8 @@ class SlurmProc(PreProcessor):
                 self.logerror("missing process name for pid {0}".format(pid))
                 continue
 
-            command = description[1][pid].split(" ", 1)[1]
+            s = description[1][pid]
+            command = s[s.find(" ") + 1:]
 
             if self.expectedcgroup in data[2][idx][0]:
                 containedprocs[pid] = command

--- a/src/supremm/preprocessors/SlurmProc.py
+++ b/src/supremm/preprocessors/SlurmProc.py
@@ -9,7 +9,9 @@ from supremm.linuxhelpers import parsecpusallowed
 import re
 import itertools
 
-GROUP_RE = re.compile(r"^cpuset:/slurm/uid_(\d+)/job_(\d+)/")
+# Removing the ^|; anchor will probably improve performance of search but may slightly alter behavior in contrived cases
+# (CPython regex library has optimizations for constant string prefixes)
+GROUP_RE = re.compile(r"(^|;)cpuset:/slurm/uid_(\d+)/job_(\d+)/")
 
 
 class SlurmProc(PreProcessor):
@@ -51,14 +53,11 @@ class SlurmProc(PreProcessor):
             the UID and jobid of each job
         """
 
-        groups = s.split(";")
-
-        for group in groups:
-            m = GROUP_RE.match(group)
-            if m:
-                return m.group(1), m.group(2)
-
-        return None, None
+        m = GROUP_RE.search(s)
+        if m:
+            return m.group(2), m.group(3)
+        else:
+            return None, None
 
     @staticmethod
     def instanceparser(s):

--- a/src/supremm/preprocessors/SlurmProc.py
+++ b/src/supremm/preprocessors/SlurmProc.py
@@ -106,7 +106,7 @@ class SlurmProc(PreProcessor):
 
             command = description[1][pid].split(" ", 1)[1]
 
-            if data[2][idx][0].find(self.expectedcgroup) != -1:
+            if self.expectedcgroup in data[2][idx][0]:
                 containedprocs[pid] = command
                 cgroupedprocs.append(idx)
             else:

--- a/src/supremm/preprocessors/SlurmProc.py
+++ b/src/supremm/preprocessors/SlurmProc.py
@@ -109,18 +109,18 @@ class SlurmProc(PreProcessor):
                 cgroupedprocs.append(idx)
             else:
                 otheruid, otherjobid = self.slurmcgroupparser(data[2][idx][0])
-                if otherjobid != None:
+                if otherjobid is not None:
                     otherjobs[pid] = command
                 else:
                     unconstrainedprocs[pid] = command
 
-        if len(data) > 3 and self.cgroupcpuset == None:
+        if len(data) > 3 and self.cgroupcpuset is None:
             for cpuset in itertools.ifilter(lambda x: x[1] == self.cgrouppath, description[3].iteritems()):
                 for content in itertools.ifilter(lambda x: int(x[1]) == cpuset[0], data[3]):
                     self.cgroupcpuset = parsecpusallowed(content[0])
                     break
 
-        if self.cpusallowed == None:
+        if self.cpusallowed is None:
             allcores = set()
             for idx in cgroupedprocs:
                 allcores |= parsecpusallowed(data[0][idx][0])
@@ -137,9 +137,9 @@ class SlurmProc(PreProcessor):
 
     def hostend(self):
 
-        if self.cgroupcpuset != None:
+        if self.cgroupcpuset is not None:
             self.output['cpusallowed'][self.hostname] = list(self.cgroupcpuset)
-        elif self.cpusallowed != None:
+        elif self.cpusallowed is not None:
             self.output['cpusallowed'][self.hostname] = list(self.cpusallowed)
 
         self.cgroupcpuset = None

--- a/src/supremm/preprocessors/SlurmProc.py
+++ b/src/supremm/preprocessors/SlurmProc.py
@@ -104,7 +104,7 @@ class SlurmProc(PreProcessor):
                 self.logerror("missing process name for pid {0}".format(pid))
                 continue
 
-            command = " ".join(description[1][pid].split(" ")[1:])
+            command = description[1][pid].split(" ", 1)[1]
 
             if data[2][idx][0].find(self.expectedcgroup) != -1:
                 containedprocs[pid] = command

--- a/src/supremm/preprocessors/SlurmProc.py
+++ b/src/supremm/preprocessors/SlurmProc.py
@@ -9,9 +9,7 @@ from supremm.linuxhelpers import parsecpusallowed
 import re
 import itertools
 
-# Removing the ^|; anchor will probably improve performance of search but may slightly alter behavior in contrived cases
-# (CPython regex library has optimizations for constant string prefixes)
-GROUP_RE = re.compile(r"(^|;)cpuset:/slurm/uid_(\d+)/job_(\d+)/")
+GROUP_RE = re.compile(r"cpuset:/slurm/uid_(\d+)/job_(\d+)/")
 
 
 class SlurmProc(PreProcessor):
@@ -55,7 +53,7 @@ class SlurmProc(PreProcessor):
 
         m = GROUP_RE.search(s)
         if m:
-            return m.group(2), m.group(3)
+            return m.group(1), m.group(2)
         else:
             return None, None
 

--- a/src/supremm/preprocessors/SlurmProc.py
+++ b/src/supremm/preprocessors/SlurmProc.py
@@ -9,6 +9,9 @@ from supremm.linuxhelpers import parsecpusallowed
 import re
 import itertools
 
+GROUP_RE = re.compile(r"^cpuset:/slurm/uid_(\d+)/job_(\d+)/")
+
+
 class SlurmProc(PreProcessor):
     """ Parse and analyse the proc information for a job that ran under slurm
         where the slurm cgroups plugin was enabled. 
@@ -49,15 +52,13 @@ class SlurmProc(PreProcessor):
         """
 
         groups = s.split(";")
-        groupre = re.compile(r"^cpuset:/slurm/uid_(\d+)/job_(\d+)/")
 
         for group in groups:
-            m = groupre.match(group)
+            m = GROUP_RE.match(group)
             if m:
                 return m.group(1), m.group(2)
 
         return None, None
-
 
     @staticmethod
     def instanceparser(s):


### PR DESCRIPTION
Profiling has shown that the SlurmProc preprocessor accounts for over 30% of the long-term time of summarize_jobs. This PR makes optimizations which reduce the total time spent in this preprocessor by around a factor of 3.