### PR TITLE
Support both SLURM and TORQUE cgroups.

### DIFF
--- a/src/supremm/errors.py
+++ b/src/supremm/errors.py
@@ -62,5 +62,11 @@ class ProcessingError(object):
         """ get """
         return self._id
 
+class NotApplicableError(Exception):
+    """ Used by plugins to indicate that their analysis is not avaiable for
+        the HPC job. For example, if a plugin implements a resource-manager-specific
+        analysis and the job was not run on the supported resource manager. """
+    pass
+
 if __name__ == "__main__":
     print ProcessingError.doc()

--- a/src/supremm/plugins/CgroupMemTimeseries.py
+++ b/src/supremm/plugins/CgroupMemTimeseries.py
@@ -1,18 +1,14 @@
 #!/usr/bin/env python
 """ Timeseries generator module """
 
-from supremm.plugin import Plugin
-from supremm.subsample import TimeseriesAccumulator
-from supremm.errors import ProcessingError
+from collections import Counter
 import numpy
 
-from sys import version as python_version
-if python_version.startswith("2.6"):
-    from backport_collections import Counter
-else:
-    from collections import Counter
+from supremm.plugin import Plugin
+from supremm.subsample import TimeseriesAccumulator
+from supremm.errors import ProcessingError, NotApplicableError
 
-class SlurmCgroupMemTimeseries(Plugin):
+class CgroupMemTimeseries(Plugin):
     """ Generate timeseries summary for memory usage viewed from CGroup
         This code is SLURM-specific because of the SLURM cgroup naming convention.
     """
@@ -24,11 +20,16 @@ class SlurmCgroupMemTimeseries(Plugin):
     derivedMetrics = property(lambda x: [])
 
     def __init__(self, job):
-        super(SlurmCgroupMemTimeseries, self).__init__(job)
+        super(CgroupMemTimeseries, self).__init__(job)
         self._data = TimeseriesAccumulator(job.nodecount, self._job.walltime)
         self._hostdata = {}
         self._hostcounts = {}
-        self._expectedcgroup = "/slurm/uid_{0}/job_{1}".format(job.acct['uid'], job.job_id)
+        if job.acct['resource_manager'] == 'pbs':
+            self._expectedcgroup = "/torque/{0}".format(job.job_id)
+        elif job.acct['resource_manager'] == 'slurm':
+            self._expectedcgroup = "/slurm/uid_{0}/job_{1}".format(job.acct['uid'], job.job_id)
+        else:
+            raise NotApplicableError
 
     def process(self, nodemeta, timestamp, data, description):
 

--- a/src/supremm/preprocessors/Proc.py
+++ b/src/supremm/preprocessors/Proc.py
@@ -1,42 +1,53 @@
 #!/usr/bin/env python
 """ Proc information pre-processor """
 
+import re
+import itertools
 from collections import Counter
 
 from supremm.plugin import PreProcessor
 from supremm.errors import ProcessingError
 from supremm.linuxhelpers import parsecpusallowed
-import re
-import itertools
 
-GROUP_RE = re.compile(r"cpuset:/slurm/uid_(\d+)/job_(\d+)/")
+SLURM_CGROUP_RE = re.compile(r"cpuset:/slurm/uid_(\d+)/job_(\d+)/")
+TORQUE_CGROUP_RE = re.compile(r"cpuset:/torque/(\d+(?:\[\d+\])?)(?:\.[^\.].*)?")
 
 
-class SlurmProc(PreProcessor):
-    """ Parse and analyse the proc information for a job that ran under slurm
-        where the slurm cgroups plugin was enabled. 
+class Proc(PreProcessor):
+    """ Parse and analyse the proc information for a job. Supports parsing the cgroup information
+        from SLRUM and PBS/Torque (if available).
     """
 
     name = property(lambda x: "proc")
     mode = property(lambda x: "timeseries")
     requiredMetrics = property(lambda x: [
-        [ "proc.psinfo.cpusallowed",
-        "proc.id.uid_nm",
-        "proc.psinfo.cgroups" ],
-        [ "hotproc.psinfo.cpusallowed",
-        "hotproc.id.uid_nm",
-        "hotproc.psinfo.cgroups" ] 
+        ["proc.psinfo.cpusallowed",
+         "proc.id.uid_nm",
+         "proc.psinfo.cgroups"],
+        ["hotproc.psinfo.cpusallowed",
+         "hotproc.id.uid_nm",
+         "hotproc.psinfo.cgroups"]
         ])
 
     optionalMetrics = property(lambda x: ["cgroup.cpuset.cpus"])
     derivedMetrics = property(lambda x: [])
 
     def __init__(self, job):
-        super(SlurmProc, self).__init__(job)
+        super(Proc, self).__init__(job)
 
-        self.expectedslurmscript = "/var/spool/slurmd/job" + job.job_id + "/slurm_script"
-        self.cgrouppath = "/slurm/uid_" + str(job.acct['uid']) + "/job_" + job.job_id
-        self.expectedcgroup = "cpuset:" + self.cgrouppath
+        self.cgrouppath = None
+        self.expectedcgroup = None
+        self.cgroupparser = None
+
+        if job.acct['resource_manager'] == 'slurm':
+            self.cgrouppath = "/slurm/uid_" + str(job.acct['uid']) + "/job_" + job.job_id
+            self.expectedcgroup = "cpuset:" + self.cgrouppath
+            self.cgroupparser = self.slurmcgroupparser
+        elif job.acct['resource_manager'] == 'pbs':
+            self.cgrouppath = "/torque/" + job.job_id
+            self.expectedcgroup = "cpuset:" + self.cgrouppath
+            self.cgroupparser = self.torquecgroupparser
+
         self.jobusername = job.acct['user']
 
         self.cpusallowed = None
@@ -46,31 +57,34 @@ class SlurmProc(PreProcessor):
         self.output = {"procDump": {"constrained": Counter(), "unconstrained": Counter()}, "cpusallowed": {}}
 
     @staticmethod
+    def torquecgroupparser(s):
+        """ Parse linux cgroup string for slurm-specific settings and extract
+            the jobid of each job
+        """
+        m = TORQUE_CGROUP_RE.search(s)
+        if m:
+            return None, m.group(1)
+
+        return None, None
+
+    @staticmethod
     def slurmcgroupparser(s):
         """ Parse linux cgroup string for slurm-specific settings and extract
             the UID and jobid of each job
         """
 
-        m = GROUP_RE.search(s)
+        m = SLURM_CGROUP_RE.search(s)
         if m:
             return m.group(1), m.group(2)
         else:
             return None, None
-
-    @staticmethod
-    def instanceparser(s):
-        tokens = s.split(" ")
-
-        pid = tokens[0]
-        cmd = tokens[1:]
-
-        return pid,cmd
 
     def hoststart(self, hostname):
         self.hostname = hostname
         self.output['cpusallowed'][hostname] = {"error": ProcessingError.RAW_COUNTER_UNAVAILABLE}
 
     def logerror(self, info):
+        """ record error information """
         if 'errors' not in self.output:
             self.output['errors'] = {}
         if self.hostname not in self.output['errors']:
@@ -105,17 +119,20 @@ class SlurmProc(PreProcessor):
             s = description[1][pid]
             command = s[s.find(" ") + 1:]
 
-            if self.expectedcgroup in data[2][idx][0]:
-                containedprocs[pid] = command
-                cgroupedprocs.append(idx)
-            else:
-                otheruid, otherjobid = self.slurmcgroupparser(data[2][idx][0])
-                if otherjobid is not None:
-                    otherjobs[pid] = command
+            if self.cgroupparser is not None:
+                if self.expectedcgroup in data[2][idx][0]:
+                    containedprocs[pid] = command
+                    cgroupedprocs.append(idx)
                 else:
-                    unconstrainedprocs[pid] = command
+                    _, otherjobid = self.cgroupparser(data[2][idx][0])
+                    if otherjobid is not None:
+                        otherjobs[pid] = command
+                    else:
+                        unconstrainedprocs[pid] = command
+            else:
+                unconstrainedprocs[pid] = command
 
-        if len(data) > 3 and self.cgroupcpuset is None:
+        if len(data) > 3 and self.cgrouppath is not None and self.cgroupcpuset is None:
             for cpuset in itertools.ifilter(lambda x: x[1] == self.cgrouppath, description[3].iteritems()):
                 for content in itertools.ifilter(lambda x: int(x[1]) == cpuset[0], data[3]):
                     self.cgroupcpuset = parsecpusallowed(content[0])
@@ -175,4 +192,3 @@ class SlurmProc(PreProcessor):
             i += 1
 
         return {'procDump': result}
-

--- a/src/supremm/xdmodaccount.py
+++ b/src/supremm/xdmodaccount.py
@@ -42,7 +42,8 @@ class XDMoDAcct(Accounting):
                     jf.`exit_state` AS `exit_status`,
                     jf.`cpu_req` AS `reqcpus`,
                     jf.`mem_req` AS `reqmem`,
-                    jf.`timelimit` AS `timelimit`
+                    jf.`timelimit` AS `timelimit`,
+                    sj.`source_format` AS `resource_manager`
                 FROM
                     modw.job_tasks jf
                         INNER JOIN
@@ -53,6 +54,8 @@ class XDMoDAcct(Accounting):
                     modw.account aa ON jr.account_id = aa.id
                         LEFT JOIN
                     modw_supremm.`process` p ON jf.job_id = p.jobid
+                        LEFT JOIN
+                    mod_shredder.`shredded_job` sj ON jf.job_id = sj.shredded_job_id
                 WHERE
                     jf.resource_id = %s
             """
@@ -81,7 +84,8 @@ class XDMoDAcct(Accounting):
                     jf.`exit_state` as `exit_status`,
                     jf.`cpu_req` as `reqcpus`,
                     jf.`mem_req` as `reqmem`,
-                    jf.`timelimit` as `timelimit`
+                    jf.`timelimit` as `timelimit`,
+                    sj.`source_format` AS `resource_manager`
                 FROM
                     modw.jobfact jf
                 LEFT JOIN
@@ -90,6 +94,8 @@ class XDMoDAcct(Accounting):
                     modw.systemaccount sa ON jf.systemaccount_id = sa.id
                 INNER JOIN
                     modw.account aa ON jf.account_id = aa.id
+                LEFT JOIN
+                    mod_shredder.`shredded_job` sj ON jf.job_id = sj.shredded_job_id
                 WHERE
                     jf.resource_id = %s
             """


### PR DESCRIPTION
There are three plugins that make use of cgroup information: the SlurmProc preprocessor and the CGroupMemory and CGroupMemTimeseries anayltics. Previously they only supported slurm-style
cgroup paths and have now been updated for torque.

In order to support different resource managers, the resource manager type is now pulled from the XDMoD database and this information is available in a plugin. Plugins can now signal that they do
not support a given configuration by throwing a NotApplicableError exception in the constructor.