### PR TITLE
Support both SLURM and TORQUE cgroups. (continued)

### DIFF
--- a/src/supremm/errors.py
+++ b/src/supremm/errors.py
@@ -62,5 +62,11 @@ class ProcessingError(object):
         """ get """
         return self._id
 
+class NotApplicableError(Exception):
+    """ Used by plugins to indicate that their analysis is not avaiable for
+        the HPC job. For example, if a plugin implements a resource-manager-specific
+        analysis and the job was not run on the supported resource manager. """
+    pass
+
 if __name__ == "__main__":
     print ProcessingError.doc()

--- a/src/supremm/plugins/CgroupMemory.py
+++ b/src/supremm/plugins/CgroupMemory.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """ Memory usage plugin """
 
+import re
 from supremm.plugin import Plugin
 from supremm.statistics import RollingStats, calculate_stats
 from supremm.errors import ProcessingError, NotApplicableError
@@ -43,8 +44,14 @@ class CgroupMemory(Plugin):
             return True
 
         try:
-            dataidx = description[0][1].index(self._expectedcgroup)
-
+            dataidx = None
+            for idx, desc in enumerate(description[0][1]):
+                if re.match(r"^" + re.escape(self._expectedcgroup) + r"($|\.)", desc):
+                    dataidx = idx
+                    break
+            # No cgroup info at this datapoint
+            if dataidx is None:
+                return True
             for i in xrange(len(self.requiredMetrics)):
                 if len(data[i]) < dataidx:
                     # Skip timesteps with incomplete information

--- a/src/supremm/xdmodaccount.py
+++ b/src/supremm/xdmodaccount.py
@@ -42,7 +42,8 @@ class XDMoDAcct(Accounting):
                     jf.`exit_state` AS `exit_status`,
                     jf.`cpu_req` AS `reqcpus`,
                     jf.`mem_req` AS `reqmem`,
-                    jf.`timelimit` AS `timelimit`
+                    jf.`timelimit` AS `timelimit`,
+                    sj.`source_format` AS `resource_manager`
                 FROM
                     modw.job_tasks jf
                         INNER JOIN
@@ -53,6 +54,8 @@ class XDMoDAcct(Accounting):
                     modw.account aa ON jr.account_id = aa.id
                         LEFT JOIN
                     modw_supremm.`process` p ON jf.job_id = p.jobid
+                        LEFT JOIN
+                    mod_shredder.`shredded_job` sj ON jf.job_id = sj.shredded_job_id
                 WHERE
                     jf.resource_id = %s
             """
@@ -81,7 +84,8 @@ class XDMoDAcct(Accounting):
                     jf.`exit_state` as `exit_status`,
                     jf.`cpu_req` as `reqcpus`,
                     jf.`mem_req` as `reqmem`,
-                    jf.`timelimit` as `timelimit`
+                    jf.`timelimit` as `timelimit`,
+                    sj.`source_format` AS `resource_manager`
                 FROM
                     modw.jobfact jf
                 LEFT JOIN
@@ -90,6 +94,8 @@ class XDMoDAcct(Accounting):
                     modw.systemaccount sa ON jf.systemaccount_id = sa.id
                 INNER JOIN
                     modw.account aa ON jf.account_id = aa.id
+                LEFT JOIN
+                    mod_shredder.`shredded_job` sj ON jf.job_id = sj.shredded_job_id
                 WHERE
                     jf.resource_id = %s
             """


### PR DESCRIPTION
Update memory cgroup matching to support Torque cgroups
    
SUPReMM code looks for something like `/torque/123` while the actual cgroup may be `/torque/123.batch-server.example.com`
    
Cgroup memory parsing will also exit early if `dataidx` is None as `data[None]` was returning lists of results instead of raising exceptions

Regex matching:

```python
>>> import re
>>> s = "/slurm/uid_123/job_1"
>>> e = "/slurm/uid_123/job_1"
>>> re.match(r"^" + re.escape(e) + r"($|\.)", s)
<_sre.SRE_Match object at 0x7f531a4b9558>
>>> s = "/torque/123.batch-server"
>>> e = "/torque/123"
>>> re.match(r"^" + re.escape(e) + r"($|\.)", s)
<_sre.SRE_Match object at 0x7f531a4b95d0>
>>> s = "/torque/123"
>>> e = "/torque/123"
>>> re.match(r"^" + re.escape(e) + r"($|\.)", s)
<_sre.SRE_Match object at 0x7f531a4b9558>
```