### PR TITLE
Add missing python-psutil dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_rpm]
 release = 1%{?dist}
 build_requires = python-devel pcp-libs-devel
-requires = python-pymongo numpy scipy MySQL-python python-pcp pcp Cython %{?el6:python-backport_collections}
+requires = python-pymongo numpy scipy MySQL-python python-pcp pcp Cython %{?el6:python-backport_collections} python-psutil
 install_script = .rpm_install_script.txt


### PR DESCRIPTION
EPEL calls the package `python2-psutil` but installing `python-psutil` works too.

Without this change:

```
[root@xdmod ~]# indexarchives.py -a -d
Traceback (most recent call last):
  File "/bin/indexarchives.py", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 3007, in <module>
    working_set.require(__requires__)
  File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 728, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 626, in resolve
    raise DistributionNotFound(req)
pkg_resources.DistributionNotFound: psutil
```

```
yum install python-psutil
<snip>
[root@xdmod ~]# indexarchives.py -a -d
2018-07-26T10:35:55.363 [DEBUG] Using config file /etc/supremm/config.json
<SNIP success>
```