### PR TITLE
Fix plugin results() exception handling

### DIFF
--- a/src/supremm/summarize_jobs.py
+++ b/src/supremm/summarize_jobs.py
@@ -98,6 +98,7 @@ def process_resource(resconf, preprocs, plugins, config, opts):
                     continue  # Extract-only mode
                 s, mdata, success, s_err = res
                 summarize_time = time.time() - summarize_start
+                summary_dict = s.get()
             except Exception as e:
                 logging.error("Failure for summarization of job %s %s. Error: %s %s", job.job_id, job.jobdir, str(e), traceback.format_exc())
                 clean_jobdir(opts, job)
@@ -106,7 +107,7 @@ def process_resource(resconf, preprocs, plugins, config, opts):
                 else:
                     continue
 
-            process_summary(m, dbif, opts, job, summarize_time, (s.get(), mdata, success, s_err))
+            process_summary(m, dbif, opts, job, summarize_time, (summary_dict, mdata, success, s_err))
             clean_jobdir(opts, job)
 
 
@@ -148,14 +149,15 @@ def do_summarize(args):
             return job, None, None  # Extract-only mode
         s, mdata, success, s_err = res
         summarize_time = time.time() - summarize_start
+        # Ensure Summarize.get() is called on worker process since it is cpu-intensive
+        summary_dict = s.get()
     except Exception as e:
         logging.error("Failure for summarization of job %s %s. Error: %s %s", job.job_id, job.jobdir, str(e), traceback.format_exc())
         if opts["fail_fast"]:
             raise
         return job, None, None
 
-    # Ensure Summarize.get() is called on worker process since it is cpu-intensive
-    return job, (s.get(), mdata, success, s_err), summarize_time
+    return job, (summary_dict, mdata, success, s_err), summarize_time
 
 
 def main():

--- a/tests/integration_tests/integration_plugin_api.py
+++ b/tests/integration_tests/integration_plugin_api.py
@@ -3,6 +3,8 @@ from mock import patch
 
 from supremm import summarize_jobs
 from mock_preprocessor import MockPreprocessor
+from tests.integration_tests.throwing_plugin import ThrowingPlugin, InitThrowingPlugin
+
 
 def test_plugin_api():
     test_args = "summarize_jobs.py -d -r 2 -j 972366 --fail-fast".split()
@@ -12,3 +14,14 @@ def test_plugin_api():
     # you have to patch loadpreprocs as if it was in the summarize_jobs module
     with patch.object(sys, "argv", test_args), patch("supremm.summarize_jobs.loadpreprocessors",  return_value=preprocs), patch("supremm.summarize_jobs.loadplugins", return_value=plugins):
         summarize_jobs.main()
+
+
+def test_exception_handling():
+    test_args = "summarize_jobs.py -d -r 2 -j 972366".split()
+    plugins = [InitThrowingPlugin, ThrowingPlugin]
+    preprocs = []
+    # this was very non-obvious to me but since summarize_jobs does "from supremm.plugin import loadpreprocs"
+    # you have to patch loadpreprocs as if it was in the summarize_jobs module
+    with patch.object(sys, "argv", test_args), patch("supremm.summarize_jobs.loadpreprocessors",  return_value=preprocs), patch("supremm.summarize_jobs.loadplugins", return_value=plugins):
+        summarize_jobs.main()
+

--- a/tests/integration_tests/integration_plugin_api.py
+++ b/tests/integration_tests/integration_plugin_api.py
@@ -1,13 +1,15 @@
 import sys
 from mock import patch
+import pytest
 
 from supremm import summarize_jobs
 from mock_preprocessor import MockPreprocessor
 from tests.integration_tests.throwing_plugin import InitThrowingPlugin, ProcessThrowingPlugin, ResultsThrowingPlugin
 
 
-def test_plugin_api():
-    test_args = "summarize_jobs.py -d -r 2 -j 972366 --fail-fast".split()
+@pytest.mark.parametrize("threads", [1, 3])
+def test_plugin_api(threads):
+    test_args = "summarize_jobs.py -d -r 2 -j 972366 --fail-fast --threads {}".format(threads).split()
     preprocs = [MockPreprocessor]
     plugins = []
     # this was very non-obvious to me but since summarize_jobs does "from supremm.plugin import loadpreprocs"
@@ -16,24 +18,27 @@ def test_plugin_api():
         summarize_jobs.main()
 
 
-def test_exception_init():
-    test_args = "summarize_jobs.py -d -r 2 -j 972366".split()
+@pytest.mark.parametrize("threads", [1, 3])
+def test_exception_init(threads):
+    test_args = "summarize_jobs.py -d -r 2 -j 972366 --threads {}".format(threads).split()
     plugins = [InitThrowingPlugin]
     preprocs = []
     with patch.object(sys, "argv", test_args), patch("supremm.summarize_jobs.loadpreprocessors",  return_value=preprocs), patch("supremm.summarize_jobs.loadplugins", return_value=plugins):
         summarize_jobs.main()
 
 
-def test_exception_process():
-    test_args = "summarize_jobs.py -d -r 2 -j 972366".split()
+@pytest.mark.parametrize("threads", [1, 3])
+def test_exception_process(threads):
+    test_args = "summarize_jobs.py -d -r 2 -j 972366 --threads {}".format(threads).split()
     plugins = [ProcessThrowingPlugin]
     preprocs = []
     with patch.object(sys, "argv", test_args), patch("supremm.summarize_jobs.loadpreprocessors",  return_value=preprocs), patch("supremm.summarize_jobs.loadplugins", return_value=plugins):
         summarize_jobs.main()
 
 
-def test_exception_results():
-    test_args = "summarize_jobs.py -d -r 2 -j 972366".split()
+@pytest.mark.parametrize("threads", [1, 3])
+def test_exception_results(threads):
+    test_args = "summarize_jobs.py -d -r 2 -j 972366 --threads {}".format(threads).split()
     plugins = [ResultsThrowingPlugin]
     preprocs = []
     with patch.object(sys, "argv", test_args), patch("supremm.summarize_jobs.loadpreprocessors",  return_value=preprocs), patch("supremm.summarize_jobs.loadplugins", return_value=plugins):

--- a/tests/integration_tests/integration_plugin_api.py
+++ b/tests/integration_tests/integration_plugin_api.py
@@ -3,7 +3,7 @@ from mock import patch
 
 from supremm import summarize_jobs
 from mock_preprocessor import MockPreprocessor
-from tests.integration_tests.throwing_plugin import ThrowingPlugin, InitThrowingPlugin
+from tests.integration_tests.throwing_plugin import InitThrowingPlugin, ProcessThrowingPlugin, ResultsThrowingPlugin
 
 
 def test_plugin_api():
@@ -16,12 +16,25 @@ def test_plugin_api():
         summarize_jobs.main()
 
 
-def test_exception_handling():
+def test_exception_init():
     test_args = "summarize_jobs.py -d -r 2 -j 972366".split()
-    plugins = [InitThrowingPlugin, ThrowingPlugin]
+    plugins = [InitThrowingPlugin]
     preprocs = []
-    # this was very non-obvious to me but since summarize_jobs does "from supremm.plugin import loadpreprocs"
-    # you have to patch loadpreprocs as if it was in the summarize_jobs module
     with patch.object(sys, "argv", test_args), patch("supremm.summarize_jobs.loadpreprocessors",  return_value=preprocs), patch("supremm.summarize_jobs.loadplugins", return_value=plugins):
         summarize_jobs.main()
 
+
+def test_exception_process():
+    test_args = "summarize_jobs.py -d -r 2 -j 972366".split()
+    plugins = [ProcessThrowingPlugin]
+    preprocs = []
+    with patch.object(sys, "argv", test_args), patch("supremm.summarize_jobs.loadpreprocessors",  return_value=preprocs), patch("supremm.summarize_jobs.loadplugins", return_value=plugins):
+        summarize_jobs.main()
+
+
+def test_exception_results():
+    test_args = "summarize_jobs.py -d -r 2 -j 972366".split()
+    plugins = [ResultsThrowingPlugin]
+    preprocs = []
+    with patch.object(sys, "argv", test_args), patch("supremm.summarize_jobs.loadpreprocessors",  return_value=preprocs), patch("supremm.summarize_jobs.loadplugins", return_value=plugins):
+        summarize_jobs.main()

--- a/tests/integration_tests/integration_test.bash
+++ b/tests/integration_tests/integration_test.bash
@@ -14,4 +14,4 @@ EOF
 
 [[ $count -eq 1 ]]
 
-pytest tests/integration_tests/integration_plugin_api.py
+pytest -s tests/integration_tests/integration_plugin_api.py

--- a/tests/integration_tests/integration_test.bash
+++ b/tests/integration_tests/integration_test.bash
@@ -14,4 +14,4 @@ EOF
 
 [[ $count -eq 1 ]]
 
-pytest -s tests/integration_tests/integration_plugin_api.py
+pytest tests/integration_tests/integration_plugin_api.py

--- a/tests/integration_tests/throwing_plugin.py
+++ b/tests/integration_tests/throwing_plugin.py
@@ -19,18 +19,35 @@ class InitThrowingPlugin(Plugin):
         pass
 
 
-class ThrowingPlugin(Plugin):
-    name = property(lambda self: "throwing_plugin")
+class ProcessThrowingPlugin(Plugin):
+    name = property(lambda self: "process_throwing_plugin")
     mode = property(lambda self: "timeseries")
     requiredMetrics = property(lambda self: ["hinv.ncpu", "gpfs.fsios.read_bytes"])
     optionalMetrics = property(lambda self: [])
     derivedMetrics = property(lambda self: [])
 
     def __init__(self, job):
-        super(ThrowingPlugin, self).__init__(job)
+        super(ProcessThrowingPlugin, self).__init__(job)
 
     def process(self, nodemeta, timestamp, data, description):
         raise Exception("Exception in process")
+
+    def results(self):
+        pass
+
+
+class ResultsThrowingPlugin(Plugin):
+    name = property(lambda self: "results_throwing_plugin")
+    mode = property(lambda self: "timeseries")
+    requiredMetrics = property(lambda self: ["hinv.ncpu", "gpfs.fsios.read_bytes"])
+    optionalMetrics = property(lambda self: [])
+    derivedMetrics = property(lambda self: [])
+
+    def __init__(self, job):
+        super(ResultsThrowingPlugin, self).__init__(job)
+
+    def process(self, nodemeta, timestamp, data, description):
+        return False
 
     def results(self):
         raise Exception("Exception in results")

--- a/tests/integration_tests/throwing_plugin.py
+++ b/tests/integration_tests/throwing_plugin.py
@@ -1,0 +1,36 @@
+from supremm.plugin import Plugin
+
+
+class InitThrowingPlugin(Plugin):
+    name = property(lambda self: "init_throwing_plugin")
+    mode = property(lambda self: "timeseries")
+    requiredMetrics = property(lambda self: ["hinv.ncpu", "gpfs.fsios.read_bytes"])
+    optionalMetrics = property(lambda self: [])
+    derivedMetrics = property(lambda self: [])
+
+    def __init__(self, job):
+        super(InitThrowingPlugin, self).__init__(job)
+        raise Exception("Exception in __init__")
+
+    def process(self, nodemeta, timestamp, data, description):
+        pass
+
+    def results(self):
+        pass
+
+
+class ThrowingPlugin(Plugin):
+    name = property(lambda self: "throwing_plugin")
+    mode = property(lambda self: "timeseries")
+    requiredMetrics = property(lambda self: ["hinv.ncpu", "gpfs.fsios.read_bytes"])
+    optionalMetrics = property(lambda self: [])
+    derivedMetrics = property(lambda self: [])
+
+    def __init__(self, job):
+        super(ThrowingPlugin, self).__init__(job)
+
+    def process(self, nodemeta, timestamp, data, description):
+        raise Exception("Exception in process")
+
+    def results(self):
+        raise Exception("Exception in results")


### PR DESCRIPTION
Moves the call to Summary.get() inside the current summarize try/catch blocks to properly handle exceptions within a plugin results() method.

Add mock plugins and tests to the plugin api integration tests which throw exceptions in different areas of the plugin, verifying that this does not cause an exception in the overall summarize_jobs run.