### PR TITLE
Initial workaround to allow SIGINT with multiproc pool

### DIFF
--- a/src/supremm/summarize_jobs.py
+++ b/src/supremm/summarize_jobs.py
@@ -121,7 +121,13 @@ def process_resource_multiprocessing(resconf, preprocs, plugins, config, opts, p
         jobs = get_jobs(opts, dbif)
 
         it = iter_jobs(jobs, config, resconf, plugins, preprocs, opts)
-        for job, result, summarize_time in pool.imap_unordered(do_summarize, it):
+        pool_iter = pool.imap_unordered(do_summarize, it)
+        while True:
+            try:
+                job, result, summarize_time = pool_iter.next(timeout=600)
+            except StopIteration:
+                break
+
             if result is not None:
                 process_summary(m, dbif, opts, job, summarize_time, result)
                 clean_jobdir(opts, job)


### PR DESCRIPTION
Condition waits with no timeouts do not handle signals due to a bug in
python, so need to manually iterate over the pool map and specify a
timeout.

600 second timeout is arbitrary, all that matters is that there's a number there instead of unbounded for it to catch the signal. 