### PR TITLE
Fix a typo in the pmlogger config

### DIFF
--- a/config/templates/pmlogger/pmlogger-supremm.config
+++ b/config/templates/pmlogger/pmlogger-supremm.config
@@ -165,7 +165,7 @@ log mandatory on %{standard_freq} {
     mem.numa.util.inactive_anon
     mem.numa.util.inactive_file
     mem.numa.util.mapped
-    mem.numa.util.NFS_unstable
+    mem.numa.util.NFS_Unstable
     mem.numa.util.pageTables
     mem.numa.util.slab
     mem.numa.util.used


### PR DESCRIPTION
In updating the pmlogger config template, I lost one of Trey's
changes that fixed a typo.