### PR TITLE
Update job id parsing for job arrays

### DIFF
--- a/src/supremm/assets/modw_supremm.sql
+++ b/src/supremm/assets/modw_supremm.sql
@@ -48,6 +48,8 @@ DROP TABLE IF EXISTS `archives_joblevel`;
 CREATE TABLE `archives_joblevel` (
       `archive_id` int(11) NOT NULL,
       `host_id` int(11) NOT NULL,
+      `local_jobid` int(11) NOT NULL DEFAULT '-1',
+      `local_job_array_index` int(11) NOT NULL DEFAULT '-1',
       `local_job_id_raw` int(11) NOT NULL,
       `start_time_ts` int(11) NOT NULL,
       `end_time_ts` int(11) NOT NULL,

--- a/src/supremm/migrations/1.0-1.1/modw_supremm.sql
+++ b/src/supremm/migrations/1.0-1.1/modw_supremm.sql
@@ -21,6 +21,8 @@ CREATE TABLE `archives_nodelevel` (
 CREATE TABLE `archives_joblevel` (
     `archive_id` int(11) NOT NULL,
     `host_id` int(11) NOT NULL,
+    `local_jobid` int(11) NOT NULL DEFAULT '-1',
+    `local_job_array_index` int(11) NOT NULL DEFAULT '-1',
     `local_job_id_raw` int(11) NOT NULL,
     `start_time_ts` int(11) NOT NULL,
     `end_time_ts` int(11) NOT NULL,
@@ -33,6 +35,26 @@ INSERT INTO `archive_paths` SELECT id, filename FROM archive;
 
 INSERT INTO `archives_nodelevel` SELECT id, hostid, FLOOR(start_time_ts), CEILING(end_time_ts) FROM `archive` WHERE jobid IS NULL;
 
-INSERT INTO `archives_joblevel` SELECT id, hostid, CAST(`jobid` AS SIGNED), FLOOR(start_time_ts), CEILING(end_time_ts) FROM `archive` WHERE jobid IS NOT NULL;
+INSERT INTO `archives_joblevel`
+    SELECT
+        id, hostid, - 1, - 1, CAST(`jobid` AS SIGNED), FLOOR(start_time_ts), CEILING(end_time_ts)
+    FROM
+        `archive`
+    WHERE
+        jobid IS NOT NULL AND jobid RLIKE '^[0-9]+$';
 
+INSERT INTO `archives_joblevel`
+    SELECT
+        id, hostid, SUBSTRING_INDEX(jobid, '[', 1), TRIM( TRAILING ']' FROM SUBSTRING_INDEX(jobid, '[', -1)), -1, FLOOR(start_time_ts), CEILING(end_time_ts)
+    FROM
+        `archive`
+    WHERE
+        jobid IS NOT NULL AND jobid RLIKE '^[0-9]+\[[0-9]+\]$';
 
+INSERT INTO `archives_joblevel`
+    SELECT
+        id, hostid, SUBSTRING_INDEX(jobid, '_', 1), SUBSTRING_INDEX(jobid, '_', -1), -1, FLOOR(start_time_ts), CEILING(end_time_ts)
+    FROM
+        `archive`
+    WHERE
+        jobid IS NOT NULL AND jobid RLIKE '^[0-9]+_[0-9]+$';

--- a/tests/testPcpArchiveProcessor.py
+++ b/tests/testPcpArchiveProcessor.py
@@ -1,0 +1,43 @@
+"""" tests for the pcp archive processor """
+import unittest
+from supremm.indexarchives import PcpArchiveProcessor
+
+class TestPcpArchiveProcessor(unittest.TestCase):
+    """ Tests for the pcp filename string parser code """
+
+    def setUp(self):
+        """ setUp """
+        self.inst = PcpArchiveProcessor({'hostname_mode': 'hostname'})
+
+    def test_jobidparser(self):
+        """ test jobid parsing """
+
+        testCases = {
+            'jo.log.ex.e-end-20180614.09.48.29.index': None,
+            '20180729.04.36.index': None,
+            'job-2671016.index': (-1, -1, 2671016),
+            'job-2673760.index': (-1, -1, 2673760),
+            'job-2671022.login.example.edu-end-20180830.02.54.25.index': (-1, -1, 2671022),
+            'job-2673760.login.example.edu-end-20180830.02.40.28.index': (-1, -1, 2673760),
+            'job-2673760.login.example.edu-end-20180830.02.50.16.index': (-1, -1, 2673760),
+            'job-1450543.login.example.edu-postbegin-20180830.00.00.00.index': (-1, -1, 1450543),
+            'job-1450554.login.example.edu-postbegin-20180830.00.00.00.index': (-1, -1, 1450554),
+            'job-2676199[18].index': (2676199, 18, -1),
+            'job-2679009[431].index': (2679009, 431, -1),
+            'job-1451551[326].hd-20180614.13.26.33.index': (1451551, 326, -1),
+            'job-2676200[18].login.example.edu-end-20180830.02.45.38.index': (2676200, 18, -1),
+            'job-2676200[18].login.example.edu-end-20180830.02.46.54.index': (2676200, 18, -1),
+            'job-2679009[431].login.example.edu-end-20180904.18.38.02.index': (2679009, 431, -1),
+            'job-2679136[520].login.example.edu-postbegin-20180614.00.00.00.index': (2679136, 520, -1),
+            'job-2679136[523].login.example.edu-postbegin-20180614.00.00.00.index': (2679136, 523, -1),
+            'job-1450512[4].login.example.edu-postbegin-20180614.00.00.00.index': (1450512, 4, -1),
+            'job-123423-end-20181004.04.05.41.index': (-1, -1, 123423),
+            'job-123423[234]-end-20181004.04.05.41.index': (123423, 234, -1),
+            'job-123423[]-end-20181004.04.05.41.index': (-1, -1, 123423),
+            'job-end-20181004.04.05.41.index': None,
+            'job-123423[234].server.net-end-20181004.04.05.41.index': (123423, 234, -1),
+            'job-123423.server.net-end-20181004.04.05.41.index': (-1, -1, 123423)
+        }
+
+        for archiveName, expected in testCases.iteritems():
+            assert self.inst.parsejobid(archiveName) == expected


### PR DESCRIPTION
Update the archives_joblevel table to store identifying information
for job array jobs and update the archive indexer to populate this.