### PR TITLE
Fix RPM dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.1.0] (2) - 2018-12-07
+
+### Fixed
+- Fix dependency list for the RPM build.
+
 ## [1.1.0] - 2018-10-31
 
 ### Added

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_rpm]
-release = 1%{?dist}
+release = 2%{?dist}
 build_requires = python-devel pcp-libs-devel
-requires = python-pymongo numpy scipy MySQL-python python-pcp pcp Cython pytz python-tzlocal %{?el6:python-backport_collections}
+requires = python python-pymongo numpy scipy MySQL-python python-pcp pcp Cython pytz python-tzlocal %{?el6:python-backport_collections}
 install_script = .rpm_install_script.txt


### PR DESCRIPTION
Observed this error with the latest Centos:
```
Running transaction check
ERROR with transaction check vs depsolve:
/bin/python is needed by supremm-1.1.0-1.el7.x86_64
```

This is mitigated by adding python as an explicit dependency (rather than it being an autodetected dependency)