### PR TITLE
Robustness improvements for pre-processors

### DIFF
--- a/src/supremm/linuxhelpers.py
+++ b/src/supremm/linuxhelpers.py
@@ -17,10 +17,10 @@ def parsecpusallowed(cpusallowed):
             try:
                 cpurange = [int(x) for x in item.split("-")]
                 if len(cpurange) != 2:
-                    raise Exception("Unable to parse cpusallowed \"" + cpusallowed + "\"")
+                    raise ValueError("Unable to parse cpusallowed \"" + cpusallowed + "\"")
                 cpulist |= set(range(cpurange[0], cpurange[1] + 1))
             except ValueError as e:
-                raise Exception("Unable to parse cpusallowed \"" + cpusallowed + "\"")
+                raise ValueError("Unable to parse cpusallowed \"" + cpusallowed + "\"")
 
     return cpulist
 

--- a/src/supremm/preprocessors/PerfEvent.py
+++ b/src/supremm/preprocessors/PerfEvent.py
@@ -28,7 +28,7 @@ class PerfEvent(PreProcessor):
         if self.perfactive == False:
             return False
 
-        if len(data) == 1 and data[0][:, 0].size > 0:
+        if len(data) == 1 and data[0].shape == (1, 1) and data[0][:, 0].size > 0:
             self.perfactive = data[0][0, 0] != 0
             return self.perfactive
 

--- a/src/supremm/summarize.py
+++ b/src/supremm/summarize.py
@@ -215,7 +215,14 @@ class Summarize(object):
                 if exp.args[0] == c_pmapi.PM_ERR_EOL:
                     done = True
                 else:
+                    preproc.status = "failure"
+                    preproc.hostend()
                     raise exp
+            except Exception as exp:
+                preproc.status = "failure"
+                preproc.hostend()
+                raise exp
+
 
         preproc.status = "complete"
         preproc.hostend()


### PR DESCRIPTION
If a pre-processor throw an exception then the hostend() function may not be called. This leaves the preprocessor in an inconsistent state. This change ensures that the hostend() is always called. Also an update to the `parsecpusallowed` to throw the right exception (this type of exception is handled already in the SlumProc) and extra defensive checks for the PerfEvent preproc.