### PR TITLE
Continue processing archives that have PM_ERR_VALUE errors

### DIFF
--- a/src/supremm/pcpcinterface/c_pcp.pxd
+++ b/src/supremm/pcpcinterface/c_pcp.pxd
@@ -15,6 +15,7 @@ cdef extern from "pcp/pmapi.h":
     int PM_ERR_INST_LOG  =  "PM_ERR_INST_LOG"
     int PM_ERR_NAME      =  "PM_ERR_NAME"
     int PM_ERR_SIGN      =  "PM_ERR_SIGN"
+    enum: PM_ERR_VALUE
 
     # pmDesc.type -- data type of metric values 
     int PM_TYPE_NOSUPPORT        = "PM_TYPE_NOSUPPORT"

--- a/src/supremm/pcpcinterface/pcpcinterface.pyx
+++ b/src/supremm/pcpcinterface/pcpcinterface.pyx
@@ -232,7 +232,11 @@ def extractValues(context, result, py_metric_id_array, mtypes, logerr):
 
     for i in xrange(numpmid):
         ninstances = res.vset[i].numval
-        if ninstances < 0:
+        if ninstances == c_pcp.PM_ERR_VALUE:
+            # Data missing at this timestep
+            PyBuffer_Release(&buf)
+            return True, True
+        elif ninstances < 0:
             logerr("pmError ({})".format(<bytes>c_pcp.pmErrStr(ninstances)))
             PyBuffer_Release(&buf)
             return None, None


### PR DESCRIPTION
The original code would give up processing an archive if it saw a metric that
returned PM_ERR_VALUE at any time point. This error is seen with the Ipmi pmda
and is not fatal. If this error is seen it ususaly occurs a few times a day.

This change make the framework skip the timestep that has the error but it will
continue to process the archive and give callbacks for subsequent data.