### PR TITLE
Update CI build and RPM deps to official PCP version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-FROM       tas-tools-ext-01.ccr.xdmod.org/xdmod-centos7:open7.5.1-supremm7.5.1-v1
+FROM       tas-tools-ext-01.ccr.xdmod.org/centos7_6-open-job_performance-8.1.0:latest
 MAINTAINER Joseph P. White <jpwhite4@buffalo.edu>
-
-RUN wget https://bintray.com/pcp/el7/rpm -O /etc/yum.repos.d/bintray-pcp-el7.repo
 
 RUN yum install -y \
     gcc \
@@ -14,8 +12,8 @@ RUN yum install -y \
     python-pymongo \
     MySQL-python \
     Cython \
-    python-pcp-3.12.2 \
-    pcp-devel-3.12.2
+    python-pcp \
+    pcp-devel
 
 RUN pip install pylint==1.8.3 coverage pytest==4.6.3 pytest-cov==2.7.1 setuptools==36.4.0 pexpect==4.4.0
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,9 @@ This section provides instructions on how to create an RPM or source packages fo
 software development or debugging. The instructions for installing the released
 packages are available on the [main website](https://supremm.xdmod.org/supremm-processing-install.html).
 
-### Centos 7
+### Centos 7 (7.6 and later)
 
-Install the PCP repository configuration following the instructions on the [pcp packages
-page][pcpbintray]. Install the EPEL repository configuration:
+Install the EPEL repository configuration:
 
     yum install epel-release
 
@@ -52,8 +51,8 @@ Install the build dependencies:
                 python-pymongo \
                 MySQL-python \
                 Cython \
-                python-pcp-3.12.2 \
-                pcp-libs-devel-3.12.2
+                python-pcp \
+                pcp-libs-devel
 
     pip install setuptools==36.4.0
 
@@ -149,4 +148,3 @@ the [GNU Lesser General Public License ("LGPL") Version 3.0][lgpl3].
 [listserv]:   http://listserv.buffalo.edu/cgi-bin/wa?SUBED1=ccr-xdmod-list&A=1
 [ghpr]:       https://help.github.com/articles/using-pull-requests/
 [pydist]:     https://setuptools.readthedocs.io/en/latest/
-[pcpbintray]: https://bintray.com/pcp/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_rpm]
 release = 1%{?dist}
-build_requires = python-devel, pcp-libs-devel >= 3.11, pcp-libs-devel < 4.0
-requires = python, python-pymongo, numpy, scipy, MySQL-python, python-pcp >= 3.11, python-pcp < 4.0, pcp-libs >= 3.11, pcp-libs < 4.0, Cython, pytz, python-tzlocal
+build_requires = python-devel, pcp-libs-devel >= 4.1, pcp-libs-devel < 5.0
+requires = python, python-pymongo, numpy, scipy, MySQL-python, python-pcp >= 4.1, python-pcp < 5.0, pcp-libs >= 4.1, pcp-libs < 5.0, Cython, pytz, python-tzlocal
 install_script = .rpm_install_script.txt

--- a/tests/integration_tests/bootstrap.sh
+++ b/tests/integration_tests/bootstrap.sh
@@ -5,7 +5,7 @@ shopt -s extglob
 python setup.py bdist_rpm
 yum install -y dist/supremm-+([0-9.])*.x86_64.rpm
 ~/bin/services start
-rm -rf /var/lib/mongodb/*
+rm -rf /var/lib/mongo/*
 mongod -f /etc/mongod.conf
 ~/bin/importmongo.sh
 

--- a/tests/integration_tests/integration_test.bash
+++ b/tests/integration_tests/integration_test.bash
@@ -17,10 +17,10 @@ EOF
 ingest_jobscripts.py
 
 count=$(mysql -ss -u root modw_supremm <<EOF
-SELECT COUNT(*) FROM \`batchscripts\` WHERE resource_id = 3 and local_job_id IN (1234234, 197155, 197199, 123424, 197186, 197182);
+SELECT COUNT(*) FROM \`job_scripts\` js , \`modw\`.\`job_tasks\` jt WHERE js.tg_job_id = jt.job_id and jt.resource_id = 3 and jt.local_jobid IN (197155, 197199, 197186, 197182);
 EOF
 )
 
-[[ $count -eq 6 ]]
+[[ $count -eq 4 ]]
 
 pytest tests/integration_tests/integration_plugin_api.py

--- a/tests/integration_tests/supremm_setup_expect.py
+++ b/tests/integration_tests/supremm_setup_expect.py
@@ -19,8 +19,11 @@ def main():
         p.sendline()
 
         while True:
-            i = p.expect(["Overwrite config file", "frearson", "mortorq", "phillips", "pozidriv", "robertson" ])
-            p.sendline()
+            i = p.expect(["Overwrite config file", "frearson", "mortorq", "phillips", "pozidriv", "robertson", "openstack", "recex", "torx"])
+            if i > 5:
+                p.sendline("n")
+                continue
+            p.sendline("y")
             if i != 0:
                 p.expect("Directory containing node-level PCP archives")
                 p.sendline()


### PR DESCRIPTION
Update the CI build to use the current XDMoD release, which is based on
the Centos 7.6.1810. There are a couple of minor updates to the test
harness to use the new XDMoD version.

This also switches the PCP dependency to be the version available in
the official Centos repository.