### PR TITLE
Add support for specifying the meaning of the job script datestamp.

### DIFF
--- a/src/supremm/supremm_setup.py
+++ b/src/supremm/supremm_setup.py
@@ -259,7 +259,8 @@ def configure_resource(display, resource_id, resource, defaults):
                "hostname_mode": "hostname",
                "host_name_ext": get_hostname_ext(),
                "pcp_log_dir": "/data/" + resource + "/pcp-logs",
-               "script_dir": "/data/" + resource + "/jobscripts"}
+               "batchscript.path": "/data/" + resource + "/jobscripts",
+               "batchscript.timestamp_mode": "start"}
 
     descriptions = {"resource_id": None,
                     "enabled": "Enable SUPReMM summarization for this resource?",
@@ -267,9 +268,10 @@ def configure_resource(display, resource_id, resource, defaults):
                     "hostname_mode": "node name unique identifier ('hostname' or 'fqdn')",
                     "host_name_ext": "domain name for resource",
                     "pcp_log_dir": "Directory containing node-level PCP archives",
-                    "script_dir": "Directory containing job launch scripts (enter [space] for none)"}
+                    "batchscript.path": "Directory containing job launch scripts (enter [space] for none)",
+                    "batchscript.timestamp_mode": "Job launch script timestamp lookup mode ('submit', 'start' or 'none')"}
 
-    keys = ["enabled", "pcp_log_dir", "batch_system", "hostname_mode", "host_name_ext", "script_dir"]
+    keys = ["enabled", "pcp_log_dir", "batch_system", "hostname_mode", "host_name_ext", "batchscript.path", "batchscript.timestamp_mode"]
 
     resdefault = {}
 
@@ -284,6 +286,9 @@ def configure_resource(display, resource_id, resource, defaults):
             del setting["host_name_ext"]
             continue
 
+        if key == "batchscript.timestamp_mode" and setting["batchscript.path"] == ' ':
+            continue
+
         setting[key] = display.prompt_input(descriptions[key], resdefault.get(key, setting[key]))
 
         if key == "enabled" and setting[key] == False:
@@ -295,6 +300,13 @@ def configure_resource(display, resource_id, resource, defaults):
 WARNING The directory {0} does not exist. Make sure to create and populate this
 directory before running the summarization software.
 """.format(setting[key]))
+
+    setting['batchscript'] = {
+        'path': setting['batchscript.path'].strip(),
+        'timestamp_mode': setting['batchscript.timestamp_mode']
+    }
+    del setting['batchscript.path']
+    del setting['batchscript.timestamp_mode']
 
     return setting
 

--- a/src/supremm/xdmodstylesetupmenu.py
+++ b/src/supremm/xdmodstylesetupmenu.py
@@ -31,7 +31,8 @@ class XDMoDStyleSetupMenu(object):
 
     def erase(self):
         """ Clear screen """
-        self.stdscr.erase()
+        self.stdscr.clear()
+        self.stdscr.refresh()
         self.row = 0
 
     def nextrow(self, increment=1):

--- a/tests/integration_tests/bootstrap.sh
+++ b/tests/integration_tests/bootstrap.sh
@@ -16,10 +16,26 @@ python tests/integration_tests/supremm_setup_expect.py
 
 cp tests/integration_tests/pcp_logs_extracted/* /data/mortorq/pcp-logs/hostname/2016/12/30
 
-# Create files containing 'job scripts'
+# Create files containing 'job scripts' for 'start' jobs
 jspath=/data/phillips/jobscripts/20170101
 mkdir $jspath
 for jobid in 197155 197182 197186 197199 1234234[21] 123424[]
+do
+    echo "Job script for job $jobid" > $jspath/$jobid.savescript
+done
+
+# Create job scripts for a submit jobs
+jspath=/data/robertson/jobscripts/20161212
+mkdir $jspath
+for jobid in 6066098
+do
+    echo "Job script for job $jobid" > $jspath/$jobid.savescript
+done
+
+# Create job script for end jobs
+jspath=/data/pozidriv/jobscripts/20161230
+mkdir $jspath
+for jobid in 983936
 do
     echo "Job script for job $jobid" > $jspath/$jobid.savescript
 done

--- a/tests/integration_tests/integration_test.bash
+++ b/tests/integration_tests/integration_test.bash
@@ -23,4 +23,11 @@ EOF
 
 [[ $count -eq 4 ]]
 
+count=$(mysql -ss -u root modw_supremm <<EOF
+SELECT COUNT(*) FROM \`job_scripts\`;
+EOF
+)
+
+[[ $count -eq 6 ]]
+
 pytest tests/integration_tests/integration_plugin_api.py

--- a/tests/integration_tests/supremm_setup_expect.py
+++ b/tests/integration_tests/supremm_setup_expect.py
@@ -2,6 +2,9 @@ import pexpect
 import sys
 
 def main():
+
+    scriptsettings = ['start', 'start', 'start', 'end', 'submit']
+
     with open("supremm_expect_log", "w") as f:
         p = pexpect.spawn('supremm-setup')
         p.logfile = f
@@ -20,6 +23,8 @@ def main():
 
         while True:
             i = p.expect(["Overwrite config file", "frearson", "mortorq", "phillips", "pozidriv", "robertson", "openstack", "recex", "torx"])
+            if i > 1:
+                p.expect('Enable SUPReMM summarization for this resource?')
             if i > 5:
                 p.sendline("n")
                 continue
@@ -33,6 +38,8 @@ def main():
                 p.sendline()
                 p.expect("Directory containing job launch scripts")
                 p.sendline()
+                p.expect("Job launch script timestamp lookup mode \('submit', 'start' or 'none'\)")
+                p.sendline(scriptsettings[i-1])
             else:
                 break
 


### PR DESCRIPTION
The jobs scripts are stored in datestamped directories. The original
code used the datestamp as the job's start time when looking up the job
information in the database. This change allows the datestamp to be
interpreted as either the submit day, start day, end day or for
the datestamp to be ignored completely.

The user facing documentation for this change is in https://github.com/ubccr/xdmod-supremm/pull/222