### PR TITLE
Recent versions of mongo shell support the uri syntax

### DIFF
--- a/src/supremm/supremm_setup.py
+++ b/src/supremm/supremm_setup.py
@@ -376,9 +376,6 @@ def create_mongodb(display):
 
     mongouri = display.prompt_string("URI", dbsettings['uri'])
 
-    if mongouri.startswith("mongodb://"):
-        mongouri = mongouri[10:]
-
     display.print_warning("""
 
 WARNING This operation will write to mongo


### PR DESCRIPTION
This code was a workaround for very early versions of the mongo shell
that did not recognise the mongodb uri syntax.