### PR TITLE
Avoid duplicate warnings when ingesting job scripts

### DIFF
--- a/src/supremm/ingest_jobscripts.py
+++ b/src/supremm/ingest_jobscripts.py
@@ -35,9 +35,9 @@ class DbHelper(object):
             pass
 
         if self.xdmod_schema_version == 7:
-            self.query = "INSERT IGNORE INTO " + self.tablename + " (resource_id,local_job_id,script) VALUES(%s,%s,%s)"
+            self.query = "INSERT INTO " + self.tablename + " (resource_id,local_job_id,script) VALUES(%s,%s,%s) ON DUPLICATE KEY UPDATE script = VALUES(script)"
         else:
-            self.query = "INSERT IGNORE INTO " + self.tablename + """ (tg_job_id, resource_id, start_date, script)
+            self.query = "INSERT INTO " + self.tablename + """ (tg_job_id, resource_id, start_date, script)
                         SELECT 
                             job_id AS tg_job_id,
                             resource_id,
@@ -47,7 +47,8 @@ class DbHelper(object):
                             `modw`.`job_tasks`
                         WHERE
                             resource_id = %s 
-                            AND local_job_id_raw = %s"""
+                            AND local_job_id_raw = %s
+                        ON DUPLICATE KEY UPDATE script = script"""
 
             if self.timestamp_mode == 'start':
                 self.query += ' AND ABS(DATEDIFF(DATE(FROM_UNIXTIME(start_time_ts)), %s)) < 2'


### PR DESCRIPTION
This was in my local changes but somehow got missed during past merges.   This is the type of log message trying to avoid:

```
Aug 15 04:00:10 xdmod-test ingest_jobscripts:  cur.execute(self.query, qdata)
Aug 15 04:00:10 xdmod-test ingest_jobscripts: 
Aug 15 04:00:10 xdmod-test ingest_jobscripts: 2020-08-15T04:00:10 [WARNING] /usr/lib64/python2.7/site-packages/supremm/ingest_jobscripts.py:74: Warning: Duplicate entry '36106174' for key 'PRIMARY'
```