### PR TITLE
Update pip version to 20.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN yum install -y \
     python-pcp \
     pcp-devel
 
+RUN pip install --upgrade pip
+
 RUN pip install zipp==1.2.0 pylint==1.8.3 coverage pytest==4.6.3 pytest-cov==2.7.1 setuptools==36.4.0 pexpect==4.4.0 configparser==3.5.0
 
 RUN pip install --ignore-installed six>=1.10.0


### PR DESCRIPTION
The version of pip we were using to pull in the development dependencies
did not understand the difference between python 2 and 3. Hence it was trying
to pull incompatible versions of the dependencies.