### PR TITLE
Add Prometheus support

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -37,6 +37,7 @@
             "enabled": true,
             "resource_id": 1,
             "batch_system": "XDMoD",
+            "metric_system": "pcp",
             "hostname_mode": "hostname",
             "pcp_log_dir": "/data/pcp-logs/my_cluster_name",
             "script_dir": "/data/jobscripts/my_cluster_name",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_rpm]
 release = 1%{?dist}
 build_requires = python-devel, pcp-libs-devel >= 4.1, pcp-libs-devel < 5.0
-requires = python, python-pymongo, numpy, scipy, MySQL-python, python-pcp >= 4.1, python-pcp < 5.0, pcp-libs >= 4.1, pcp-libs < 5.0, Cython, pytz, python-tzlocal
+requires = python, python-pymongo, numpy, scipy, MySQL-python, python-pcp >= 4.1, python-pcp < 5.0, pcp-libs >= 4.1, pcp-libs < 5.0, Cython, pytz, python-tzlocal, python-requests
 install_script = .rpm_install_script.txt

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,8 @@ setup(
         'scipy',
         'pymongo',
         'pytz',
-        'tzlocal'
+        'tzlocal',
+        'requests'
     ],
     ext_modules=cythonize([
         Extension("supremm.pcpcinterface.pcpcinterface", ["src/supremm/pcpcinterface/pcpcinterface.pyx"], libraries=["pcp"], include_dirs=[numpy.get_include()]),

--- a/src/supremm/Job.py
+++ b/src/supremm/Job.py
@@ -226,6 +226,16 @@ class Job(object):
             self._nodes[node] = JobNode(node, nodeid)
 
     @property
+    def nodes(self):
+        """
+        Get job's nodes.
+
+        Returns:
+            JobNode
+        """
+        return self._nodes
+
+    @property
     def end_datetime(self):
         """
         Gets a datetime object representing the job's end time, or None

--- a/src/supremm/TimeseriesPatterns.py
+++ b/src/supremm/TimeseriesPatterns.py
@@ -40,8 +40,8 @@ class TimeseriesPatterns(Plugin):
     def derivedMetrics(self):
         return []
 
-    def __init__(self, job):
-        super(TimeseriesPatterns, self).__init__(job)
+    def __init__(self, job, config):
+        super(TimeseriesPatterns, self).__init__(job, config)
 
         EPOCH = datetime(1970, 1, 1)
         self.start_time = (job.start_datetime - EPOCH).total_seconds()

--- a/src/supremm/account.py
+++ b/src/supremm/account.py
@@ -178,8 +178,8 @@ class DbAcct(Accounting):
     Helper class to get job records from the store
     """
 
-    def __init__(self, resource_id, conf):
-        super(DbAcct, self).__init__(resource_id, conf)
+    def __init__(self, resource_id, conf, resconf):
+        super(DbAcct, self).__init__(resource_id, conf, resconf)
 
         self._dblog = DbLogger(conf)
         dbconf = conf.getsection("accountdatabase")

--- a/src/supremm/accounting.py
+++ b/src/supremm/accounting.py
@@ -9,9 +9,10 @@ class Accounting(object):
 
     PROCESS_VERSION = 1
 
-    def __init__(self, resource_id, config):
+    def __init__(self, resource_id, config, resconf):
         self._resource_id = resource_id
         self._config = config
+        self._resconf = resconf
 
     @abstractmethod
     def getbylocaljobid(self, localjobid):

--- a/src/supremm/assets/mongo_setup.js
+++ b/src/supremm/assets/mongo_setup.js
@@ -23,6 +23,11 @@ var sdef = {
             "description": "GPU utilization %",
             "help": "The average percentage of time spent with the GPU active. The average is computed over each time interval."
         },
+        "gpu_mem_usage": {
+            "units": "GB",
+            "description": "GPU memory usage",
+            "help": "The average memory usage per GPU. The average is computed over each time interval."
+        },
         "clktks": {
             "units": "insts/s",
             "description": "Clock Ticks",

--- a/src/supremm/config.py
+++ b/src/supremm/config.py
@@ -53,6 +53,7 @@ class Config(object):
             @returns Directory name or None if no suitable directory found
         """
         searchpaths = [
+            os.getenv('SUPREMM_CONFIG_DIR', '/etc/supremm'),
             os.path.dirname(os.path.abspath(__file__)) + "/../../../../etc/supremm",
             "/etc/supremm",
             pkg_resources.resource_filename(pkg_resources.Requirement.parse("supremm"), "etc/supremm")
@@ -60,6 +61,7 @@ class Config(object):
 
         for path in searchpaths:
             if os.path.exists(os.path.join(path, "config.json")):
+                print path
                 return os.path.abspath(path)
 
         return None
@@ -118,6 +120,10 @@ class Config(object):
                 continue
             resdata['name'] = resname
             yield (resname, resdata)
+
+    def metric_configs(self):
+        metrics = self._config.get('metrics', {})
+        return metrics
 
 def test():
     """ test """

--- a/src/supremm/config.py
+++ b/src/supremm/config.py
@@ -61,7 +61,6 @@ class Config(object):
 
         for path in searchpaths:
             if os.path.exists(os.path.join(path, "config.json")):
-                print path
                 return os.path.abspath(path)
 
         return None

--- a/src/supremm/config.py
+++ b/src/supremm/config.py
@@ -121,10 +121,6 @@ class Config(object):
             resdata['name'] = resname
             yield (resname, resdata)
 
-    def metric_configs(self):
-        metrics = self._config.get('metrics', {})
-        return metrics
-
 def test():
     """ test """
     conf = Config()

--- a/src/supremm/errors.py
+++ b/src/supremm/errors.py
@@ -22,6 +22,7 @@ class ProcessingError(object):
     RAW_ARCHIVES = 17
     JOB_TOO_MANY_NODEHOURS = 18
     MAX_ERROR = 19
+    PROMETHEUS_QUERY_ERROR = 20
 
     def __init__(self, err_id):
         self._id = err_id
@@ -45,7 +46,8 @@ class ProcessingError(object):
             ProcessingError.NO_ARCHIVES: "None of the nodes in the job have pcp archives",
             ProcessingError.SUMMARIZATION_ERROR: "There were enough archives to try summarization, but too few archives were successfully processed",
             ProcessingError.RAW_ARCHIVES: "Not enough raw archives to try pmlogextract",
-            ProcessingError.JOB_TOO_MANY_NODEHOURS: "Total job node hours exceeded threshold"
+            ProcessingError.JOB_TOO_MANY_NODEHOURS: "Total job node hours exceeded threshold",
+            ProcessingError.PROMETHEUS_QUERY_ERROR: "Error querying Prometheus"
         }
         return names[self._id]
 

--- a/src/supremm/plugin.py
+++ b/src/supremm/plugin.py
@@ -459,10 +459,11 @@ class PrometheusPlugin(Plugin):
                 return None
             for r in data.get('data', {}).get('result', []):
                 if indom_label:
-                    indom = r.get('metric', {}).get(indom_label, None)
+                    m = r.get('metric', {})
+                    indom = indom_label.format(**m)
                 else:
                     indom = 'NA'
-                if indom is None:
+                if not indom:
                     logging.error("Unable to find Prometheus label to match requested indom=%s", metric.indom)
                     continue
                 if indom_label and indom not in self._data:

--- a/src/supremm/plugin.py
+++ b/src/supremm/plugin.py
@@ -632,10 +632,12 @@ class PrometheusTimeseriesNamePlugin(PrometheusPlugin):
                 self._error = ProcessingError.PROMETHEUS_QUERY_ERROR
                 return None
             for r in data.get('data', {}).get('result', []):
+                labels = r.get('metric', {})
+                name = timeseries_name.format(**labels)
                 if str(idx) not in self._devicedata:
                     self._devicedata[str(idx)] = TimeseriesAccumulator(self._job.nodecount, self._job.walltime)
-                if timeseries_name not in self._names.values():
-                    self._names[str(idx)] = timeseries_name
+                if name not in self._names.values():
+                    self._names[str(idx)] = name
                 for v in r.get('values', []):
                     value = float(v[1])
                     if v[0] not in timeseries:

--- a/src/supremm/plugin.py
+++ b/src/supremm/plugin.py
@@ -569,7 +569,7 @@ class PrometheusTimeseriesPlugin(PrometheusPlugin):
                 "min": self.collatedata(sortarr[:, 0], data),
                 "max": self.collatedata(sortarr[:, -1], data),
                 "med": self.collatedata(sortarr[:, sortarr.shape[1] / 2], data),
-                "times": values[:, :, 0].tolist(),
+                "times": values[0, :, 0].tolist(),
                 "hosts": {}
             }
 
@@ -580,7 +580,7 @@ class PrometheusTimeseriesPlugin(PrometheusPlugin):
         else:
             # Save data for all hosts
             retdata = {
-                "times": values[:, :, 0].tolist(),
+                "times": values[0, :, 0].tolist(),
                 "hosts": {}
             }
             includelist = self._hostdata.keys()
@@ -677,7 +677,7 @@ class PrometheusTimeseriesNamePlugin(PrometheusPlugin):
                 "min": self.collatedata(sortarr[:, 0], data),
                 "max": self.collatedata(sortarr[:, -1], data),
                 "med": self.collatedata(sortarr[:, sortarr.shape[1] / 2], data),
-                "times": values[:, :, 0].tolist(),
+                "times": values[0, :, 0].tolist(),
                 "hosts": {}
             }
 
@@ -688,7 +688,7 @@ class PrometheusTimeseriesNamePlugin(PrometheusPlugin):
         else:
             # Save data for all hosts
             retdata = {
-                "times": values[:, :, 0].tolist(),
+                "times": values[0, :, 0].tolist(),
                 "hosts": {}
             }
             includelist = self._hostdata.keys()

--- a/src/supremm/plugin.py
+++ b/src/supremm/plugin.py
@@ -485,7 +485,7 @@ class PrometheusPlugin(Plugin):
                 if indom_label and indom not in self._data:
                     self._data[indom] = {}
                 if not indom_label and metricname not in self._data:
-                    self._data[metricname] = {}
+                    self._data[metricname] = []
                 if indom_label and metricname not in self._data[indom]:
                     self._data[indom][metricname] = []
                 for v in r.get('values', []):
@@ -508,6 +508,9 @@ class PrometheusPlugin(Plugin):
 
         for devicename, device in self._data.iteritems():
             cleandevname = devicename.replace(".", "-")
+            if not isinstance(device, dict):
+                output[cleandevname] = calculate_stats(device)
+                continue
             output[cleandevname] = {}
             for metricname, metric in device.iteritems():
                 output[cleandevname][metricname] = calculate_stats(metric)

--- a/src/supremm/plugin.py
+++ b/src/supremm/plugin.py
@@ -426,10 +426,10 @@ class PrometheusPlugin(Plugin):
         for k,v in self.optionalMetrics.items():
             self.allmetrics[k] = v
 
-        self.metric_configs = config.metric_configs()
-        self.prometheus_url = self.metric_configs.get('prometheus_url', None)
-        self.step = self.metric_configs.get('step', '1m')
-        self.rate = rate = self.metric_configs.get('rates', {}).get(self.name, '5m')
+        summaryconf = config.getsection("summary")
+        self.prometheus_url = summaryconf.get('prometheus_url', None)
+        self.step = summaryconf.get('step', '1m')
+        self.rate = summaryconf.get('rates', {}).get(self.name, '5m')
 
     def query_range(self, query, start, end):
         headers = {

--- a/src/supremm/plugin.py
+++ b/src/supremm/plugin.py
@@ -444,8 +444,12 @@ class PrometheusPlugin(Plugin):
             'step': self.step,
         }
         url = urlparse.urljoin(self.prometheus_url, "/api/v1/query_range")
-        logging.debug('Prometheus QUERY RANGE, url="%s" params="%s"', url, params)
-        r = requests.post(url, data=params, headers=headers)
+        if self.session is None:
+            logging.debug('Prometheus QUERY RANGE, url="%s" params="%s"', url, params)
+            r = requests.post(url, data=params, headers=headers)
+        else:
+            logging.debug('Prometheus QUERY RANGE (session), url="%s" params="%s"', url, params)
+            r = self.session.post(url, data=params, headers=headers)
         if r.status_code != 200:
             return None
         data = r.json()
@@ -460,8 +464,12 @@ class PrometheusPlugin(Plugin):
             'time': str(ts),
         }
         url = urlparse.urljoin(self.prometheus_url, "/api/v1/query")
-        logging.debug('Prometheus QUERY, url="%s" params="%s"', url, params)
-        r = requests.post(url, data=params, headers=headers)
+        if self.session is None:
+            logging.debug('Prometheus QUERY, url="%s" params="%s"', url, params)
+            r = requests.post(url, data=params, headers=headers)
+        else:
+            logging.debug('Prometheus QUERY (session), url="%s" params="%s"', url, params)
+            r = self.session.post(url, data=params, headers=headers)
         if r.status_code != 200:
             return None
         data = r.json()

--- a/src/supremm/plugin.py
+++ b/src/supremm/plugin.py
@@ -432,6 +432,8 @@ class PrometheusPlugin(Plugin):
         self.rate = summaryconf.get('rates', {}).get(self.name, '5m')
         self.start_trim = int(summaryconf.get('start_trim', 30))
         self.end_trim = int(summaryconf.get('end_trim', 30))
+        self.host_label = summaryconf.get('host_label', 'host')
+        self.job_gpu_info = summaryconf.get('job_gpu_info', 'slurm_job_gpu_info')
 
     def query_range(self, query, start, end):
         headers = {

--- a/src/supremm/plugins/Block.py
+++ b/src/supremm/plugins/Block.py
@@ -6,6 +6,7 @@ class Block(DeviceBasedPlugin):
     """ This plugin processes lots of metric that are all interested in the difference over the process """
 
     name = property(lambda x: "block")
+    metric_system = property(lambda x: "pcp")
     requiredMetrics = property(lambda x: [
         "disk.dev.read",
         "disk.dev.read_bytes",
@@ -14,5 +15,3 @@ class Block(DeviceBasedPlugin):
         ])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
-
-

--- a/src/supremm/plugins/BlockPrometheus.py
+++ b/src/supremm/plugins/BlockPrometheus.py
@@ -12,19 +12,19 @@ class BlockPrometheus(PrometheusPlugin):
     requiredMetrics = property(lambda x: {
         "read": {
             'metric': 'rate(node_disk_reads_completed_total{{instance=~"^{node}.+"}}[{rate}])',
-            'indom': 'device',
+            'indom': '{device}',
         },
         "read_bytes": {
             'metric': 'rate(node_disk_read_bytes_total{{instance=~"^{node}.+"}}[{rate}])',
-            'indom': 'device',
+            'indom': '{device}',
         },
         "write": {
             'metric': 'rate(node_disk_writes_completed_total{{instance=~"^{node}.+"}}[{rate}])',
-            'indom': 'device',
+            'indom': '{device}',
         },
         "write_bytes": {
             'metric': 'rate(node_disk_written_bytes_total{{instance=~"^{node}.+"}}[{rate}])',
-            'indom': 'device',
+            'indom': '{device}',
         }
     })
     optionalMetrics = property(lambda x: {})

--- a/src/supremm/plugins/BlockPrometheus.py
+++ b/src/supremm/plugins/BlockPrometheus.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+""" Block usage plugin - https://github.com/prometheus/node_exporter"""
+
+
+from supremm.plugin import PrometheusPlugin
+
+class BlockPrometheus(PrometheusPlugin):
+    """ This plugin processes lots of metric that are all interested in the difference over the process """
+
+    name = property(lambda x: "block")
+    metric_system = property(lambda x: "prometheus")
+    requiredMetrics = property(lambda x: {
+        "read": {
+            'metric': 'rate(node_disk_reads_completed_total{{instance=~"^{node}.+"}}[{rate}])',
+            'indom': 'device',
+        },
+        "read_bytes": {
+            'metric': 'rate(node_disk_read_bytes_total{{instance=~"^{node}.+"}}[{rate}])',
+            'indom': 'device',
+        },
+        "write": {
+            'metric': 'rate(node_disk_writes_completed_total{{instance=~"^{node}.+"}}[{rate}])',
+            'indom': 'device',
+        },
+        "write_bytes": {
+            'metric': 'rate(node_disk_written_bytes_total{{instance=~"^{node}.+"}}[{rate}])',
+            'indom': 'device',
+        }
+    })
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})
+

--- a/src/supremm/plugins/BlockTimeseries.py
+++ b/src/supremm/plugins/BlockTimeseries.py
@@ -8,13 +8,14 @@ class BlockTimeseries(RateConvertingTimeseriesPlugin):
     """ Generate timeseries summary for block device usage data """
 
     name = property(lambda x: "block")
+    metric_system = property(lambda x: "pcp")
     requiredMetrics = property(lambda x: ["disk.dev.read_bytes",
                                           "disk.dev.write_bytes"])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(BlockTimeseries, self).__init__(job)
+    def __init__(self, job, config):
+        super(BlockTimeseries, self).__init__(job, config)
 
     def computetimepoint(self, data):
         return numpy.sum(numpy.array(data)) / 1048576.0

--- a/src/supremm/plugins/BlockTimeseriesPrometheus.py
+++ b/src/supremm/plugins/BlockTimeseriesPrometheus.py
@@ -12,12 +12,10 @@ class BlockTimeseriesPrometheus(PrometheusTimeseriesNamePlugin):
     requiredMetrics = property(lambda x: {
         "read_bytes": {
             'metric': 'rate(node_disk_read_bytes_total{{instance=~"^{node}.+"}}[{rate}])',
-            'indom': 'device',
             'timeseries_name': 'read'
         },
         "write_bytes": {
             'metric': 'rate(node_disk_written_bytes_total{{instance=~"^{node}.+"}}[{rate}])',
-            'indom': 'device',
             'timeseries_name': 'write',
         }
     })

--- a/src/supremm/plugins/BlockTimeseriesPrometheus.py
+++ b/src/supremm/plugins/BlockTimeseriesPrometheus.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+""" Block usage timerseries plugin - https://github.com/prometheus/node_exporter"""
+
+from supremm.plugin import PrometheusTimeseriesPlugin
+
+class BlockTimeseriesPrometheus(PrometheusTimeseriesPlugin):
+    """ This plugin processes lots of metric that are all interested in the difference over the process """
+
+    name = property(lambda x: "block")
+    metric_system = property(lambda x: "prometheus")
+    timeseries = property(lambda x: True)
+    requiredMetrics = property(lambda x: {
+        "read_bytes": {
+            'metric': 'rate(node_disk_read_bytes_total{{instance=~"^{node}.+"}}[{rate}])',
+            'indom': 'device',
+        },
+        "write_bytes": {
+            'metric': 'rate(node_disk_written_bytes_total{{instance=~"^{node}.+"}}[{rate}])',
+            'indom': 'device',
+        }
+    })
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})
+

--- a/src/supremm/plugins/BlockTimeseriesPrometheus.py
+++ b/src/supremm/plugins/BlockTimeseriesPrometheus.py
@@ -8,7 +8,6 @@ class BlockTimeseriesPrometheus(PrometheusTimeseriesNamePlugin):
 
     name = property(lambda x: "block")
     metric_system = property(lambda x: "prometheus")
-    timeseries = property(lambda x: True)
     requiredMetrics = property(lambda x: {
         "read_bytes": {
             'metric': 'rate(node_disk_read_bytes_total{{instance=~"^{node}.+"}}[{rate}])',

--- a/src/supremm/plugins/BlockTimeseriesPrometheus.py
+++ b/src/supremm/plugins/BlockTimeseriesPrometheus.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 """ Block usage timerseries plugin - https://github.com/prometheus/node_exporter"""
 
-from supremm.plugin import PrometheusTimeseriesPlugin
+from supremm.plugin import PrometheusTimeseriesNamePlugin
 
-class BlockTimeseriesPrometheus(PrometheusTimeseriesPlugin):
+class BlockTimeseriesPrometheus(PrometheusTimeseriesNamePlugin):
     """ This plugin processes lots of metric that are all interested in the difference over the process """
 
     name = property(lambda x: "block")
@@ -13,10 +13,12 @@ class BlockTimeseriesPrometheus(PrometheusTimeseriesPlugin):
         "read_bytes": {
             'metric': 'rate(node_disk_read_bytes_total{{instance=~"^{node}.+"}}[{rate}])',
             'indom': 'device',
+            'timeseries_name': 'read'
         },
         "write_bytes": {
             'metric': 'rate(node_disk_written_bytes_total{{instance=~"^{node}.+"}}[{rate}])',
             'indom': 'device',
+            'timeseries_name': 'write',
         }
     })
     optionalMetrics = property(lambda x: {})

--- a/src/supremm/plugins/BlockTimeseriesPrometheus.py
+++ b/src/supremm/plugins/BlockTimeseriesPrometheus.py
@@ -10,11 +10,11 @@ class BlockTimeseriesPrometheus(PrometheusTimeseriesNamePlugin):
     metric_system = property(lambda x: "prometheus")
     requiredMetrics = property(lambda x: {
         "read_bytes": {
-            'metric': 'rate(node_disk_read_bytes_total{{instance=~"^{node}.+"}}[{rate}])',
+            'metric': 'rate(node_disk_read_bytes_total{{instance=~"^{node}.+"}}[{rate}]) / 1024^3',
             'timeseries_name': 'read'
         },
         "write_bytes": {
-            'metric': 'rate(node_disk_written_bytes_total{{instance=~"^{node}.+"}}[{rate}])',
+            'metric': 'rate(node_disk_written_bytes_total{{instance=~"^{node}.+"}}[{rate}]) / 1024^3',
             'timeseries_name': 'write',
         }
     })

--- a/src/supremm/plugins/Catastrophe.py
+++ b/src/supremm/plugins/Catastrophe.py
@@ -9,6 +9,7 @@ class Catastrophe(Plugin):
         tacc_stats project """
 
     name = property(lambda x: "catastrophe")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "all")
     requiredMetrics = property(lambda x: [["perfevent.hwcounters.MEM_LOAD_RETIRED_L1D_HIT.value"],
                                           ["perfevent.hwcounters.L1D_REPLACEMENT.value"],
@@ -17,8 +18,8 @@ class Catastrophe(Plugin):
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(Catastrophe, self).__init__(job)
+    def __init__(self, job, config):
+        super(Catastrophe, self).__init__(job, config)
         self._data = {}
         self._error = None
 

--- a/src/supremm/plugins/CgroupMemTimeseries.py
+++ b/src/supremm/plugins/CgroupMemTimeseries.py
@@ -14,13 +14,14 @@ class CgroupMemTimeseries(Plugin):
     """
 
     name = property(lambda x: "process_mem_usage")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "timeseries")
     requiredMetrics = property(lambda x: ["cgroup.memory.usage"])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(CgroupMemTimeseries, self).__init__(job)
+    def __init__(self, job, config):
+        super(CgroupMemTimeseries, self).__init__(job, config)
         self._data = TimeseriesAccumulator(job.nodecount, self._job.walltime)
         self._hostdata = {}
         self._hostcounts = {}

--- a/src/supremm/plugins/CgroupMemTimeseriesPrometheus.py
+++ b/src/supremm/plugins/CgroupMemTimeseriesPrometheus.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+""" Memory usage plugin - https://github.com/treydock/cgroup_exporter"""
+
+from supremm.plugin import PrometheusTimeseriesPlugin
+
+class CgroupMemTimeseriesPrometheus(PrometheusTimeseriesPlugin):
+    """ Cgroup memory statistics for the job """
+
+    name = property(lambda x: "process_mem_usage")
+    metric_system = property(lambda x: "prometheus")
+    requiredMetrics = property(lambda x: {
+        "usage": {
+            'metric': '(cgroup_memory_used_bytes{{instance=~"^{node}.+"}} * on(cgroup, instance) group_left(jobid) cgroup_info{{instance=~"^{node}.+",jobid="{jobid}"}}) / 1024^3',
+        }
+    })
+
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})

--- a/src/supremm/plugins/CgroupMemory.py
+++ b/src/supremm/plugins/CgroupMemory.py
@@ -10,14 +10,15 @@ class CgroupMemory(Plugin):
     """ Cgroup memory statistics for the job """
 
     name = property(lambda x: "process_memory")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "all")
     requiredMetrics = property(lambda x: ["cgroup.memory.usage", "cgroup.memory.limit"])
 
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(CgroupMemory, self).__init__(job)
+    def __init__(self, job, config):
+        super(CgroupMemory, self).__init__(job, config)
         self._data = {}
         self._hostcounts = {}
         if job.acct['resource_manager'] == 'pbs':

--- a/src/supremm/plugins/CgroupMemoryPrometheus.py
+++ b/src/supremm/plugins/CgroupMemoryPrometheus.py
@@ -38,6 +38,9 @@ class CgroupMemoryPrometheus(PrometheusPlugin):
                 return None
             for r in data.get('data', {}).get('result', []):
                 for v in r.get('values', []):
+                    ts = int(v[0])
+                    if ts <= (mdata.start + self.start_trim) or ts >= (mdata.end - self.end_trim):
+                        continue
                     value = float(v[1])
                     if metricname not in self._data[mdata.nodeindex]:
                         self._data[mdata.nodeindex][metricname] = RollingStats()

--- a/src/supremm/plugins/CgroupMemoryPrometheus.py
+++ b/src/supremm/plugins/CgroupMemoryPrometheus.py
@@ -31,7 +31,7 @@ class CgroupMemoryPrometheus(PrometheusPlugin):
     def process(self, mdata):
         self._data[mdata.nodeindex] = {}
         for metricname, metric in self.allmetrics.items():
-            query = metric['metric'].format(node=mdata.nodename, jobid=self._job.job_id, rate='5m')
+            query = metric['metric'].format(node=mdata.nodename, jobid=self._job.job_id, rate=self.rate)
             data = self.query(query, mdata.start, mdata.end)
             if data is None:
                 self._error = ProcessingError.PROMETHEUS_QUERY_ERROR

--- a/src/supremm/plugins/CgroupMemoryPrometheus.py
+++ b/src/supremm/plugins/CgroupMemoryPrometheus.py
@@ -32,7 +32,7 @@ class CgroupMemoryPrometheus(PrometheusPlugin):
         self._data[mdata.nodeindex] = {}
         for metricname, metric in self.allmetrics.items():
             query = metric['metric'].format(node=mdata.nodename, jobid=self._job.job_id, rate=self.rate)
-            data = self.query(query, mdata.start, mdata.end)
+            data = self.query_range(query, mdata.start, mdata.end)
             if data is None:
                 self._error = ProcessingError.PROMETHEUS_QUERY_ERROR
                 return None

--- a/src/supremm/plugins/CgroupMemoryPrometheus.py
+++ b/src/supremm/plugins/CgroupMemoryPrometheus.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+""" Memory usage plugin - https://github.com/treydock/cgroup_exporter"""
+
+from supremm.plugin import PrometheusPlugin
+from supremm.statistics import RollingStats, calculate_stats
+from supremm.errors import ProcessingError
+
+class CgroupMemoryPrometheus(PrometheusPlugin):
+    """ Cgroup memory statistics for the job """
+
+    name = property(lambda x: "process_memory")
+    metric_system = property(lambda x: "prometheus")
+    requiredMetrics = property(lambda x: {
+        "usage": {
+            'metric': 'cgroup_memory_used_bytes{{instance=~"^{node}.+"}} * on(cgroup, instance) group_left(jobid) cgroup_info{{instance=~"^{node}.+",jobid="{jobid}"}}',
+        },
+        "limit": {
+            'metric': 'cgroup_memory_total_bytes{{instance=~"^{node}.+"}} * on(cgroup, instance) group_left(jobid) cgroup_info{{instance=~"^{node}.+",jobid="{jobid}"}}',
+        },
+        "usageratio": {
+            'metric': """
+            (cgroup_memory_used_bytes{{instance=~"^{node}.+"}} * on(cgroup, instance) group_left(jobid) cgroup_info{{instance=~"^{node}.+",jobid="{jobid}"}}) / 
+            (cgroup_memory_total_bytes{{instance=~"^{node}.+"}} * on(cgroup, instance) group_left(jobid) cgroup_info{{instance=~"^{node}.+",jobid="{jobid}"}})
+            """,
+        }
+    })
+
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})
+
+    def process(self, mdata):
+        self._data[mdata.nodeindex] = {}
+        for metricname, metric in self.allmetrics.items():
+            query = metric['metric'].format(node=mdata.nodename, jobid=self._job.job_id, rate='5m')
+            data = self.query(query, mdata.start, mdata.end)
+            if data is None:
+                self._error = ProcessingError.PROMETHEUS_QUERY_ERROR
+                return None
+            for r in data.get('data', {}).get('result', []):
+                for v in r.get('values', []):
+                    value = float(v[1])
+                    if metricname not in self._data[mdata.nodeindex]:
+                        self._data[mdata.nodeindex][metricname] = RollingStats()
+                    self._data[mdata.nodeindex][metricname].append(value)
+
+        return True
+
+    def results(self):
+        if self._error != None:
+            return {"error": self._error}
+        if len(self._data) != self._job.nodecount:
+            return {"error": ProcessingError.INSUFFICIENT_HOSTDATA}
+
+        stats = {"usage": {"avg": [], "max": []}, "limit": [], "usageratio": {"avg": [], "max": []}}
+
+        datapoints = 0
+
+        for memdata in self._data.itervalues():
+            for metric, values in memdata.items():
+                if values.count() > 0:
+                    datapoints += 1
+                    if metric in ['usage', 'usageratio']:
+                        stats[metric]['avg'].append(values.mean())
+                        stats[metric]['max'].append(values.max)
+                    else:
+                        stats[metric].append(values.max)
+
+        if datapoints == 0:
+            return {"error": ProcessingError.INSUFFICIENT_DATA}
+
+        result = {"usage": {}, "usageratio": {}}
+        result['usage']['avg'] = calculate_stats(stats['usage']['avg'])
+        result['usage']['max'] = calculate_stats(stats['usage']['max'])
+        result['usageratio']['avg'] = calculate_stats(stats['usageratio']['avg'])
+        result['usageratio']['max'] = calculate_stats(stats['usageratio']['max'])
+        result['limit'] = calculate_stats(stats['limit'])
+
+        return result

--- a/src/supremm/plugins/CpuPerfCounters.py
+++ b/src/supremm/plugins/CpuPerfCounters.py
@@ -45,13 +45,14 @@ class CpuPerfCounters(Plugin):
     """ Compute various performance counter derived metrics """
 
     name = property(lambda x: "cpuperf")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "firstlast")
     requiredMetrics = property(lambda x: [SNB_METRICS, NHM_METRICS, NHM_ALT_METRICS, GENERIC_INTEL_METRICS, AMD_INTERLAGOS_METRICS, GENERIC_INTEL_ALT_METRICS, GENERIC_INTEL_ALT2_METRICS])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(CpuPerfCounters, self).__init__(job)
+    def __init__(self, job, config):
+        super(CpuPerfCounters, self).__init__(job, config)
         self._first = {}
         self._data = {}
         self._totalcores = 0

--- a/src/supremm/plugins/CpuUsage.py
+++ b/src/supremm/plugins/CpuUsage.py
@@ -10,6 +10,7 @@ class CpuUsage(Plugin):
     """ Compute the overall cpu usage for a job """
 
     name = property(lambda x: "cpu")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "firstlast")
     requiredMetrics = property(lambda x: [[
             "kernel.percpu.cpu.user", 
@@ -35,8 +36,8 @@ class CpuUsage(Plugin):
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(CpuUsage, self).__init__(job)
+    def __init__(self, job, config):
+        super(CpuUsage, self).__init__(job, config)
         self._first = {}
         self._last = {}
         self._totalcores = 0

--- a/src/supremm/plugins/CpuUsagePrometheus.py
+++ b/src/supremm/plugins/CpuUsagePrometheus.py
@@ -49,7 +49,7 @@ class CpuUsagePrometheus(PrometheusPlugin):
             return {"error": ProcessingError.INSUFFICIENT_HOSTDATA}
 
         cpusallowed = self._job.getdata('proc')['cpusallowed']
-        hostcpus = self._job.getdata('proc')['hostcpus']
+        hinv = self._job.getdata('hinv')
 
         stats = {'jobcpus': {'all': {'cnt': 0}}, 'nodecpus': {'all': {'cnt': 0}}}
         results = {'nodecpus': {}, 'jobcpus': {}}
@@ -59,13 +59,13 @@ class CpuUsagePrometheus(PrometheusPlugin):
             if 'error' in usercpus:
                 results['jobcpus'] = usercpus
                 error = True
-            if isinstance(hostcpus[host], dict):
-                results['nodecpus'] = hostcpus[host]
+            if 'error' in hinv[host]:
+                results['nodecpus'] = hinv[host]
                 error = True
             if error:
                 continue
             stats['jobcpus']['all']['cnt'] += len(usercpus)
-            stats['nodecpus']['all']['cnt'] += hostcpus[host]
+            stats['nodecpus']['all']['cnt'] += hinv[host]['cores']
             for mode, cpus in modes.items():
                 if mode not in stats['jobcpus']:
                     stats['jobcpus'][mode] = []

--- a/src/supremm/plugins/CpuUsagePrometheus.py
+++ b/src/supremm/plugins/CpuUsagePrometheus.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+""" CPU Usage metrics - https://github.com/prometheus/node_exporter"""
+
+from supremm.plugin import PrometheusPlugin
+from supremm.statistics import calculate_stats
+from supremm.errors import ProcessingError
+
+class CpuUsagePrometheus(PrometheusPlugin):
+    """ Compute the overall cpu usage for a job """
+
+    name = property(lambda x: "cpu")
+    metric_system = property(lambda x: "prometheus")
+    requiredMetrics = property(lambda x: {
+        'cpu': {
+            'metric': 'rate(node_cpu_seconds_total{{instance=~"^{node}.+"}}[{rate}])'
+        }
+    })
+
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})
+
+    def process(self, mdata):
+        self._data[mdata.nodename] = {}
+        rate = self.metric_configs.get('rates', {}).get(self.name, '5m')
+        for metricname, metric in self.allmetrics.items():
+            query = metric['metric'].format(node=mdata.nodename, jobid=self._job.job_id, rate=rate)
+            data = self.query(query, mdata.start, mdata.end)
+            if data is None:
+                self._error = ProcessingError.PROMETHEUS_QUERY_ERROR
+                return None
+            for r in data.get('data', {}).get('result', []):
+                m = r.get('metric', {})
+                mode = m.get('mode', None)
+                cpu = m.get('cpu', None)
+                if mode is None or cpu is None:
+                    continue
+                self._data[mdata.nodename][mode] = {}
+                self._data[mdata.nodename][mode][cpu] = []
+                values = r.get('values', [])
+                for v in values:
+                    value = float(v[1])
+                    self._data[mdata.nodename][mode][cpu].append(value)
+        return True
+
+    def results(self):
+        error = False
+        if self._error != None:
+            return {"error": self._error}
+        if len(self._data) != self._job.nodecount:
+            return {"error": ProcessingError.INSUFFICIENT_HOSTDATA}
+
+        cpusallowed = self._job.getdata('proc')['cpusallowed']
+        hostcpus = self._job.getdata('proc')['hostcpus']
+
+        stats = {'jobcpus': {'all': {'cnt': 0}}, 'nodecpus': {'all': {'cnt': 0}}}
+        results = {'nodecpus': {}, 'jobcpus': {}}
+
+        for host, modes in self._data.items():
+            usercpus = cpusallowed[host]
+            if 'error' in usercpus:
+                results['jobcpus'] = usercpus
+                error = True
+            if isinstance(hostcpus[host], dict):
+                results['nodecpus'] = hostcpus[host]
+                error = True
+            if error:
+                continue
+            stats['jobcpus']['all']['cnt'] += len(usercpus)
+            stats['nodecpus']['all']['cnt'] += hostcpus[host]
+            for mode, cpus in modes.items():
+                if mode not in stats['jobcpus']:
+                    stats['jobcpus'][mode] = []
+                if mode not in stats['nodecpus']:
+                    stats['nodecpus'][mode] = []
+                for cpu, values in cpus.items():
+                    stats['nodecpus'][mode] = stats['nodecpus'][mode] + values
+                    if cpu not in usercpus:
+                        continue
+                    stats['jobcpus'][mode] = stats['jobcpus'][mode] + values
+
+        if error:
+            return results
+
+        for _type, modes in stats.items():
+            for mode, values in modes.items():
+                if mode == 'all':
+                    results[_type][mode] = values
+                    continue
+                results[_type][mode] = calculate_stats(values)
+
+        return results
+

--- a/src/supremm/plugins/CpuUsagePrometheus.py
+++ b/src/supremm/plugins/CpuUsagePrometheus.py
@@ -61,6 +61,9 @@ class CpuUsagePrometheus(PrometheusPlugin):
                     self._cgroupdata[mdata.nodename][mode] = []
                 values = r.get('values', [])
                 for v in values:
+                    ts = int(v[0])
+                    if ts <= (mdata.start + self.start_trim) or ts >= (mdata.end - self.end_trim):
+                        continue
                     value = float(v[1])
                     if metricname == 'cpu':
                         self._data[mdata.nodename][mode][cpu].append(value)

--- a/src/supremm/plugins/CpuUsagePrometheus.py
+++ b/src/supremm/plugins/CpuUsagePrometheus.py
@@ -21,9 +21,8 @@ class CpuUsagePrometheus(PrometheusPlugin):
 
     def process(self, mdata):
         self._data[mdata.nodename] = {}
-        rate = self.metric_configs.get('rates', {}).get(self.name, '5m')
         for metricname, metric in self.allmetrics.items():
-            query = metric['metric'].format(node=mdata.nodename, jobid=self._job.job_id, rate=rate)
+            query = metric['metric'].format(node=mdata.nodename, jobid=self._job.job_id, rate=self.rate)
             data = self.query(query, mdata.start, mdata.end)
             if data is None:
                 self._error = ProcessingError.PROMETHEUS_QUERY_ERROR

--- a/src/supremm/plugins/CpuUsagePrometheus.py
+++ b/src/supremm/plugins/CpuUsagePrometheus.py
@@ -23,7 +23,7 @@ class CpuUsagePrometheus(PrometheusPlugin):
         self._data[mdata.nodename] = {}
         for metricname, metric in self.allmetrics.items():
             query = metric['metric'].format(node=mdata.nodename, jobid=self._job.job_id, rate=self.rate)
-            data = self.query(query, mdata.start, mdata.end)
+            data = self.query_range(query, mdata.start, mdata.end)
             if data is None:
                 self._error = ProcessingError.PROMETHEUS_QUERY_ERROR
                 return None

--- a/src/supremm/plugins/CpuUserTimeseries.py
+++ b/src/supremm/plugins/CpuUserTimeseries.py
@@ -11,13 +11,14 @@ class CpuUserTimeseries(Plugin):
     """ Generate the CPU usage as a timeseries data """
 
     name = property(lambda x: "cpuuser")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "timeseries")
     requiredMetrics = property(lambda x: ["kernel.percpu.cpu.user"])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(CpuUserTimeseries, self).__init__(job)
+    def __init__(self, job, config):
+        super(CpuUserTimeseries, self).__init__(job, config)
         self._data = TimeseriesAccumulator(job.nodecount, self._job.walltime)
         self._hostdata = {}
         self._hostdevnames = {}

--- a/src/supremm/plugins/CpuUserTimeseriesPrometheus.py
+++ b/src/supremm/plugins/CpuUserTimeseriesPrometheus.py
@@ -47,7 +47,9 @@ class CpuUserTimeseriesPrometheus(PrometheusTimeseriesNamePlugin):
                 if cpuname not in self._names.values():
                     self._names[str(idx)] = cpuname
                 for v in r.get('values', []):
-                    ts = v[0]
+                    ts = int(v[0])
+                    if ts <= (mdata.start + self.start_trim) or ts >= (mdata.end - self.end_trim):
+                        continue
                     value = float(v[1])
                     if ts not in timeseries:
                         timeseries[ts] = []

--- a/src/supremm/plugins/CpuUserTimeseriesPrometheus.py
+++ b/src/supremm/plugins/CpuUserTimeseriesPrometheus.py
@@ -32,7 +32,7 @@ class CpuUserTimeseriesPrometheus(PrometheusTimeseriesNamePlugin):
                 self._error = ProcessingError.INSUFFICIENT_DATA
                 return False
             cpus_query = "^(%s)$" % '|'.join(usercpus)
-            query = metric['metric'].format(node=mdata.nodename, jobid=self._job.job_id, rate='5m', cpus=cpus_query)
+            query = metric['metric'].format(node=mdata.nodename, jobid=self._job.job_id, rate=self.rate, cpus=cpus_query)
             data = self.query(query, mdata.start, mdata.end)
             if data is None:
                 self._error = ProcessingError.PROMETHEUS_QUERY_ERROR

--- a/src/supremm/plugins/CpuUserTimeseriesPrometheus.py
+++ b/src/supremm/plugins/CpuUserTimeseriesPrometheus.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+""" Timeseries generator module - https://github.com/prometheus/node_exporter"""
+
+from supremm.plugin import PrometheusTimeseriesNamePlugin
+from supremm.subsample import TimeseriesAccumulator
+from supremm.errors import ProcessingError
+import numpy
+from collections import OrderedDict
+
+class CpuUserTimeseriesPrometheus(PrometheusTimeseriesNamePlugin):
+    """ Generate the CPU usage as a timeseries data """
+
+    name = property(lambda x: "cpuuser")
+    metric_system = property(lambda x: "prometheus")
+    requiredMetrics = property(lambda x: {
+        'cpu': {
+            'metric': 'rate(node_cpu_seconds_total{{instance=~"^{node}.+",mode="user",cpu=~"{cpus}"}}[{rate}])'
+        }
+    })
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})
+
+    def process(self, mdata):
+        timeseries = OrderedDict()
+        cpusallowed = self._job.getdata('proc').get('cpusallowed', {})
+        if mdata.nodeindex not in self._hostdata:
+            self._hostdata[mdata.nodeindex] = 1
+        idx = 0
+        for metricname, metric in self.allmetrics.items():
+            usercpus = cpusallowed.get(mdata.nodename, None)
+            if usercpus is None:
+                self._error = ProcessingError.INSUFFICIENT_DATA
+                return False
+            cpus_query = "^(%s)$" % '|'.join(usercpus)
+            query = metric['metric'].format(node=mdata.nodename, jobid=self._job.job_id, rate='5m', cpus=cpus_query)
+            data = self.query(query, mdata.start, mdata.end)
+            if data is None:
+                self._error = ProcessingError.PROMETHEUS_QUERY_ERROR
+                return None
+            for r in data.get('data', {}).get('result', []):
+                cpu = r.get('metric', {}).get('cpu', None)
+                if cpu is None:
+                    continue
+                cpuname = "cpu%s" % cpu
+                if str(idx) not in self._devicedata:
+                    self._devicedata[str(idx)] = TimeseriesAccumulator(self._job.nodecount, self._job.walltime)
+                if cpuname not in self._names.values():
+                    self._names[str(idx)] = cpuname
+                for v in r.get('values', []):
+                    ts = v[0]
+                    value = float(v[1])
+                    if ts not in timeseries:
+                        timeseries[ts] = []
+                    timeseries[ts].append(value)
+                    self._devicedata[str(idx)].adddata(mdata.nodeindex, ts, value)
+                idx += 1
+        for ts, values in timeseries.items():
+            value = numpy.mean(values)
+            self._data.adddata(mdata.nodeindex, ts, value)
+
+        return True

--- a/src/supremm/plugins/CpuUserTimeseriesPrometheus.py
+++ b/src/supremm/plugins/CpuUserTimeseriesPrometheus.py
@@ -33,7 +33,7 @@ class CpuUserTimeseriesPrometheus(PrometheusTimeseriesNamePlugin):
                 return False
             cpus_query = "^(%s)$" % '|'.join(usercpus)
             query = metric['metric'].format(node=mdata.nodename, jobid=self._job.job_id, rate=self.rate, cpus=cpus_query)
-            data = self.query(query, mdata.start, mdata.end)
+            data = self.query_range(query, mdata.start, mdata.end)
             if data is None:
                 self._error = ProcessingError.PROMETHEUS_QUERY_ERROR
                 return None

--- a/src/supremm/plugins/CpuUserTimeseriesPrometheus.py
+++ b/src/supremm/plugins/CpuUserTimeseriesPrometheus.py
@@ -14,7 +14,7 @@ class CpuUserTimeseriesPrometheus(PrometheusTimeseriesNamePlugin):
     metric_system = property(lambda x: "prometheus")
     requiredMetrics = property(lambda x: {
         'cpu': {
-            'metric': 'rate(node_cpu_seconds_total{{instance=~"^{node}.+",mode="user",cpu=~"{cpus}"}}[{rate}])'
+            'metric': 'rate(node_cpu_seconds_total{{instance=~"^{node}.+",mode="user",cpu=~"{cpus}"}}[{rate}]) * 100'
         }
     })
     optionalMetrics = property(lambda x: {})

--- a/src/supremm/plugins/Gpfs.py
+++ b/src/supremm/plugins/Gpfs.py
@@ -6,6 +6,7 @@ class Gpfs(DeviceBasedPlugin):
     """ This plugin processes lots of metric that are all interested in the difference over the process """
 
     name = property(lambda x: "gpfs")
+    metric_system = property(lambda x: "pcp")
     requiredMetrics = property(lambda x: [
         "gpfs.fsios.read_bytes",
         "gpfs.fsios.write_bytes",

--- a/src/supremm/plugins/GpfsPrometheus.py
+++ b/src/supremm/plugins/GpfsPrometheus.py
@@ -11,19 +11,19 @@ class GpfsPrometheus(PrometheusPlugin):
     requiredMetrics = property(lambda x: {
         "read": {
             'metric': 'rate(gpfs_perf_operations{{instance=~"^{node}.+",operation="reads"}}[{rate}])',
-            'indom': 'fs',
+            'indom': '{fs}',
         },
         "read_bytes": {
             'metric': 'rate(gpfs_perf_read_bytes{{instance=~"^{node}.+"}}[{rate}])',
-            'indom': 'fs',
+            'indom': '{fs}',
         },
         "write": {
             'metric': 'rate(gpfs_perf_operations{{instance=~"^{node}.+",operation="writes"}}[{rate}])',
-            'indom': 'fs',
+            'indom': '{fs}',
         },
         "write_bytes": {
             'metric': 'rate(gpfs_perf_write_bytes{{instance=~"^{node}.+"}}[{rate}])',
-            'indom': 'fs',
+            'indom': '{fs}',
         }
     })
     optionalMetrics = property(lambda x: {})

--- a/src/supremm/plugins/GpfsPrometheus.py
+++ b/src/supremm/plugins/GpfsPrometheus.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+"""https://github.com/treydock/gpfs_exporter"""
+
+from supremm.plugin import PrometheusPlugin
+
+class GpfsPrometheus(PrometheusPlugin):
+    """ Collect GPFS metrics from Prometheus """
+
+    name = property(lambda x: "gpfs")
+    metric_system = property(lambda x: "prometheus")
+    requiredMetrics = property(lambda x: {
+        "read": {
+            'metric': 'rate(gpfs_perf_operations{{instance=~"^{node}.+",operation="reads"}}[{rate}])',
+            'indom': 'fs',
+        },
+        "read_bytes": {
+            'metric': 'rate(gpfs_perf_read_bytes{{instance=~"^{node}.+"}}[{rate}])',
+            'indom': 'fs',
+        },
+        "write": {
+            'metric': 'rate(gpfs_perf_operations{{instance=~"^{node}.+",operation="writes"}}[{rate}])',
+            'indom': 'fs',
+        },
+        "write_bytes": {
+            'metric': 'rate(gpfs_perf_write_bytes{{instance=~"^{node}.+"}}[{rate}])',
+            'indom': 'fs',
+        }
+    })
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})
+
+

--- a/src/supremm/plugins/GpfsTimeseries.py
+++ b/src/supremm/plugins/GpfsTimeseries.py
@@ -7,7 +7,7 @@ import numpy
 class GpfsTimeseries(RateConvertingTimeseriesPlugin):
     """ Generate the GPFS usage as a timeseries data """
 
-    name = property(lambda x: "lnet")
+    name = property(lambda x: "gpfs")
     metric_system = property(lambda x: "pcp")
     requiredMetrics = property(lambda x: ["gpfs.fsios.read_bytes", "gpfs.fsios.write_bytes"])
     optionalMetrics = property(lambda x: [])

--- a/src/supremm/plugins/GpfsTimeseries.py
+++ b/src/supremm/plugins/GpfsTimeseries.py
@@ -7,7 +7,7 @@ import numpy
 class GpfsTimeseries(RateConvertingTimeseriesPlugin):
     """ Generate the GPFS usage as a timeseries data """
 
-    name = property(lambda x: "gpfs")
+    name = property(lambda x: "lnet")
     metric_system = property(lambda x: "pcp")
     requiredMetrics = property(lambda x: ["gpfs.fsios.read_bytes", "gpfs.fsios.write_bytes"])
     optionalMetrics = property(lambda x: [])

--- a/src/supremm/plugins/GpfsTimeseries.py
+++ b/src/supremm/plugins/GpfsTimeseries.py
@@ -8,12 +8,13 @@ class GpfsTimeseries(RateConvertingTimeseriesPlugin):
     """ Generate the GPFS usage as a timeseries data """
 
     name = property(lambda x: "lnet")
+    metric_system = property(lambda x: "pcp")
     requiredMetrics = property(lambda x: ["gpfs.fsios.read_bytes", "gpfs.fsios.write_bytes"])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(GpfsTimeseries, self).__init__(job)
+    def __init__(self, job, config):
+        super(GpfsTimeseries, self).__init__(job, config)
 
     def computetimepoint(self, data):
         return (numpy.sum(data[0]) + numpy.sum(data[1])) / 1048576.0

--- a/src/supremm/plugins/GpfsTimeseriesPrometheus.py
+++ b/src/supremm/plugins/GpfsTimeseriesPrometheus.py
@@ -2,9 +2,6 @@
 """https://github.com/treydock/gpfs_exporter"""
 
 from supremm.plugin import PrometheusTimeseriesNamePlugin
-from supremm.subsample import TimeseriesAccumulator
-from supremm.errors import ProcessingError
-from collections import OrderedDict
 
 class GpfsTimeseriesPrometheus(PrometheusTimeseriesNamePlugin):
     """ Collect GPFS metrics from Prometheus """
@@ -14,45 +11,12 @@ class GpfsTimeseriesPrometheus(PrometheusTimeseriesNamePlugin):
     requiredMetrics = property(lambda x: {
         "read_bytes": {
             'metric': 'rate(gpfs_perf_read_bytes{{instance=~"^{node}.+"}}[{rate}])',
-            'timeseries_name': 'read',
+            'timeseries_name': '{fs}-read',
         },
         "write_bytes": {
             'metric': 'rate(gpfs_perf_write_bytes{{instance=~"^{node}.+"}}[{rate}])',
-            'timeseries_name': 'write',
+            'timeseries_name': '{fs}-write',
         }
     })
     optionalMetrics = property(lambda x: {})
     derivedMetrics = property(lambda x: {})
-
-    def process(self, mdata):
-        timeseries = OrderedDict()
-        idx = 0
-        if mdata.nodeindex not in self._hostdata:
-            self._hostdata[mdata.nodeindex] = 1
-        for metricname, metric in self.allmetrics.items():
-            timeseries_name = metric['timeseries_name']
-            query = metric['metric'].format(node=mdata.nodename, jobid=self._job.job_id, rate=self.rate)
-            data = self.query_range(query, mdata.start, mdata.end)
-            if data is None:
-                self._error = ProcessingError.PROMETHEUS_QUERY_ERROR
-                return None
-            for r in data.get('data', {}).get('result', []):
-                fs = r.get('metric', {}).get('fs', None)
-                if fs is None:
-                    self._error = ProcessingError.INSUFFICIENT_DATA
-                    return False
-                if str(idx) not in self._devicedata:
-                    self._devicedata[str(idx)] = TimeseriesAccumulator(self._job.nodecount, self._job.walltime)
-                name = "%s-%s" % (fs, timeseries_name)
-                if name not in self._names.values():
-                    self._names[str(idx)] = name
-                for v in r.get('values', []):
-                    value = float(v[1])
-                    if v[0] not in timeseries:
-                        timeseries[v[0]] = 0
-                    timeseries[v[0]] += value
-                    self._devicedata[str(idx)].adddata(mdata.nodeindex, v[0], value)
-                idx += 1
-        for t, v in timeseries.items():
-            self._data.adddata(mdata.nodeindex, t, v)
-        return True

--- a/src/supremm/plugins/GpfsTimeseriesPrometheus.py
+++ b/src/supremm/plugins/GpfsTimeseriesPrometheus.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+"""https://github.com/treydock/gpfs_exporter"""
+
+from supremm.plugin import PrometheusTimeseriesNamePlugin
+from supremm.subsample import TimeseriesAccumulator
+from supremm.errors import ProcessingError
+from collections import OrderedDict
+
+class GpfsTimeseriesPrometheus(PrometheusTimeseriesNamePlugin):
+    """ Collect GPFS metrics from Prometheus """
+
+    name = property(lambda x: "gpfs")
+    metric_system = property(lambda x: "prometheus")
+    requiredMetrics = property(lambda x: {
+        "read_bytes": {
+            'metric': 'rate(gpfs_perf_read_bytes{{instance=~"^{node}.+"}}[{rate}])',
+            'timeseries_name': 'read',
+        },
+        "write_bytes": {
+            'metric': 'rate(gpfs_perf_write_bytes{{instance=~"^{node}.+"}}[{rate}])',
+            'timeseries_name': 'write',
+        }
+    })
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})
+
+    def process(self, mdata):
+        timeseries = OrderedDict()
+        idx = 0
+        if mdata.nodeindex not in self._hostdata:
+            self._hostdata[mdata.nodeindex] = 1
+        for metricname, metric in self.allmetrics.items():
+            timeseries_name = metric['timeseries_name']
+            query = metric['metric'].format(node=mdata.nodename, jobid=self._job.job_id, rate=self.rate)
+            data = self.query(query, mdata.start, mdata.end)
+            if data is None:
+                self._error = ProcessingError.PROMETHEUS_QUERY_ERROR
+                return None
+            for r in data.get('data', {}).get('result', []):
+                fs = r.get('metric', {}).get('fs', None)
+                if fs is None:
+                    self._error = ProcessingError.INSUFFICIENT_DATA
+                    return False
+                if str(idx) not in self._devicedata:
+                    self._devicedata[str(idx)] = TimeseriesAccumulator(self._job.nodecount, self._job.walltime)
+                name = "%s-%s" % (fs, timeseries_name)
+                if name not in self._names.values():
+                    self._names[str(idx)] = name
+                for v in r.get('values', []):
+                    value = float(v[1])
+                    if v[0] not in timeseries:
+                        timeseries[v[0]] = 0
+                    timeseries[v[0]] += value
+                    self._devicedata[str(idx)].adddata(mdata.nodeindex, v[0], value)
+                idx += 1
+        for t, v in timeseries.items():
+            self._data.adddata(mdata.nodeindex, t, v)
+        return True

--- a/src/supremm/plugins/GpfsTimeseriesPrometheus.py
+++ b/src/supremm/plugins/GpfsTimeseriesPrometheus.py
@@ -6,15 +6,15 @@ from supremm.plugin import PrometheusTimeseriesNamePlugin
 class GpfsTimeseriesPrometheus(PrometheusTimeseriesNamePlugin):
     """ Collect GPFS metrics from Prometheus """
 
-    name = property(lambda x: "gpfs")
+    name = property(lambda x: "lnet")
     metric_system = property(lambda x: "prometheus")
     requiredMetrics = property(lambda x: {
         "read_bytes": {
-            'metric': 'rate(gpfs_perf_read_bytes{{instance=~"^{node}.+"}}[{rate}])',
+            'metric': 'rate(gpfs_perf_read_bytes{{instance=~"^{node}.+"}}[{rate}]) / 1024^2',
             'timeseries_name': '{fs}-read',
         },
         "write_bytes": {
-            'metric': 'rate(gpfs_perf_write_bytes{{instance=~"^{node}.+"}}[{rate}])',
+            'metric': 'rate(gpfs_perf_write_bytes{{instance=~"^{node}.+"}}[{rate}]) / 1024^2',
             'timeseries_name': '{fs}-write',
         }
     })

--- a/src/supremm/plugins/GpfsTimeseriesPrometheus.py
+++ b/src/supremm/plugins/GpfsTimeseriesPrometheus.py
@@ -32,7 +32,7 @@ class GpfsTimeseriesPrometheus(PrometheusTimeseriesNamePlugin):
         for metricname, metric in self.allmetrics.items():
             timeseries_name = metric['timeseries_name']
             query = metric['metric'].format(node=mdata.nodename, jobid=self._job.job_id, rate=self.rate)
-            data = self.query(query, mdata.start, mdata.end)
+            data = self.query_range(query, mdata.start, mdata.end)
             if data is None:
                 self._error = ProcessingError.PROMETHEUS_QUERY_ERROR
                 return None

--- a/src/supremm/plugins/GpuMemUsageTimeseriesPrometheus.py
+++ b/src/supremm/plugins/GpuMemUsageTimeseriesPrometheus.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+""" Block usage timerseries plugin - https://github.com/NVIDIA/gpu-monitoring-tools"""
+
+from supremm.plugin import PrometheusTimeseriesNamePlugin
+from supremm.subsample import TimeseriesAccumulator
+from supremm.errors import ProcessingError
+import numpy
+from collections import OrderedDict
+
+class GpuMemUsageTimeseriesPrometheus(PrometheusTimeseriesNamePlugin):
+    """ This plugin processes lots of metric that are all interested in the difference over the process """
+
+    name = property(lambda x: "gpu_mem_usage")
+    metric_system = property(lambda x: "prometheus")
+    requiredMetrics = property(lambda x: {
+        'memused': {
+            'metrics': [
+                '(DCGM_FI_DEV_FB_USED{{instance=~"^{node}.+"}} / 1024) * ON({host_label},gpu) {job_gpu_info}{{instance=~"^{node}.+",jobid="{jobid}"}}',
+                '(DCGM_FI_DEV_FB_USED{{instance=~"^{node}.+"}} / 1024) * ON(gpu) {job_gpu_info}{{instance=~"^{node}.+",jobid="{jobid}"}}',
+                '(DCGM_FI_DEV_FB_USED{{instance=~"^{node}.+"}} / 1024)',
+            ],
+            'timeseries_name': 'gpu{gpu}',
+        }
+    })
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})
+
+    def process(self, mdata):
+        timeseries = OrderedDict()
+        idx = 0
+        if mdata.nodeindex not in self._hostdata:
+            self._hostdata[mdata.nodeindex] = 1
+        for metricname, metric in self.allmetrics.items():
+            timeseries_name = metric['timeseries_name']
+            results = []
+            for query_metric in metric['metrics']:
+                if len(results) > 0:
+                    continue
+                query = query_metric.format(node=mdata.nodename, jobid=self._job.job_id, rate=self.rate, host_label=self.host_label, job_gpu_info=self.job_gpu_info)
+                data = self.query_range(query, mdata.start, mdata.end)
+                if data is None:
+                    self._error = ProcessingError.PROMETHEUS_QUERY_ERROR
+                    return None
+                results = data.get('data', {}).get('result', [])
+            for r in results:
+                labels = r.get('metric', {})
+                name = timeseries_name.format(**labels)
+                if str(idx) not in self._devicedata:
+                    self._devicedata[str(idx)] = TimeseriesAccumulator(self._job.nodecount, self._job.walltime)
+                if name not in self._names.values():
+                    self._names[str(idx)] = name
+                for v in r.get('values', []):
+                    ts = int(v[0])
+                    if ts <= (mdata.start + self.start_trim) or ts >= (mdata.end - self.end_trim):
+                        continue
+                    value = float(v[1])
+                    if v[0] not in timeseries:
+                        timeseries[v[0]] = 0
+                    timeseries[v[0]] += value
+                    self._devicedata[str(idx)].adddata(mdata.nodeindex, v[0], value)
+                idx += 1
+        for t, v in timeseries.items():
+            self._data.adddata(mdata.nodeindex, t, v)
+        return True

--- a/src/supremm/plugins/GpuPower.py
+++ b/src/supremm/plugins/GpuPower.py
@@ -9,13 +9,14 @@ class GpuPower(Plugin):
     """ Compute the power statistics for a job """
 
     name = property(lambda x: "gpupower")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "all")
     requiredMetrics = property(lambda x: ["nvidia.powerused"])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(GpuPower, self).__init__(job)
+    def __init__(self, job, config):
+        super(GpuPower, self).__init__(job, config)
         self._data = {}
 
     def process(self, nodemeta, timestamp, data, description):

--- a/src/supremm/plugins/GpuPowerPrometheus.py
+++ b/src/supremm/plugins/GpuPowerPrometheus.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+""" Energy usage plugin - https://github.com/NVIDIA/gpu-monitoring-tools"""
+
+from supremm.plugin import PrometheusPlugin
+from supremm.statistics import RollingStats, calculate_stats, Integrator
+from supremm.errors import ProcessingError
+
+class GpuPowerPrometheus(PrometheusPlugin):
+    """ Compute the power statistics for a job """
+
+    name = property(lambda x: "gpupower")
+    metric_system = property(lambda x: "prometheus")
+    requiredMetrics = property(lambda x: {
+        'power': {
+            'metric': 'DCGM_FI_DEV_POWER_USAGE{{instance=~"^{node}.+"}}',
+        }
+    })
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})
+
+    def process(self, mdata):
+        """ Power measurements are similar to the memory measurements the first and last data points
+        are ignored and the statistics are computed over all of the other measurements.
+        """
+        self._data[mdata.nodename] = {}
+        for metricname, metric in self.allmetrics.items():
+            query = metric['metric'].format(node=mdata.nodename, rate=self.rate)
+            data = self.query_range(query, mdata.start, mdata.end)
+            if data is None:
+                self._error = ProcessingError.PROMETHEUS_QUERY_ERROR
+                return None
+            for r in data.get('data', {}).get('result', []):
+                gpu = r.get('metric', {}).get('gpu', None)
+                if gpu is None:
+                    self._error = ProcessingError.INSUFFICIENT_DATA
+                    return False
+                name = "gpu%s" % gpu
+                if name not in self._data[mdata.nodename]:
+                    self._data[mdata.nodename][name] = {
+                        'power': RollingStats(),
+                        'energy': Integrator(mdata.start),
+                    }
+                for v in r.get('values', []):
+                    ts = v[0]
+                    value = float(v[1])
+                    self._data[mdata.nodename][name]['power'].append(value)
+                    self._data[mdata.nodename][name]['energy'].add(ts, value)
+
+        return True
+
+    def results(self):
+        result = {}
+        for nodename, devices in self._data.items():
+            for devicename, data in devices.items():
+                if data['power'].count() < 1:
+                    continue
+                if devicename not in result:
+                    result[devicename] = {"meanpower": [], "maxpower": [], "energy": []}
+                result[devicename]["meanpower"].append(data['power'].mean())
+                result[devicename]["maxpower"].append(data['power'].max)
+                result[devicename]["energy"].append(data['energy'].total)
+
+        if not result:
+            return {"error": ProcessingError.INSUFFICIENT_DATA}
+
+        output = {}
+        for device, data in result.items():
+            output[device] = {
+                "power": {
+                    "mean": calculate_stats(data['meanpower']),
+                    "max": calculate_stats(data['maxpower'])
+                },
+                "energy": calculate_stats(data['energy'])
+            }
+            output[device]['energy']['total'] = output[device]['energy']['avg'] * output[device]['energy']['cnt']
+
+        return output

--- a/src/supremm/plugins/GpuPowerPrometheus.py
+++ b/src/supremm/plugins/GpuPowerPrometheus.py
@@ -41,7 +41,9 @@ class GpuPowerPrometheus(PrometheusPlugin):
                         'energy': Integrator(mdata.start),
                     }
                 for v in r.get('values', []):
-                    ts = v[0]
+                    ts = int(v[0])
+                    if ts <= (mdata.start + self.start_trim) or ts >= (mdata.end - self.end_trim):
+                        continue
                     value = float(v[1])
                     self._data[mdata.nodename][name]['power'].append(value)
                     self._data[mdata.nodename][name]['energy'].add(ts, value)

--- a/src/supremm/plugins/GpuUsage.py
+++ b/src/supremm/plugins/GpuUsage.py
@@ -8,13 +8,14 @@ class GpuUsage(Plugin):
     """ Compute the overall gpu usage for a job """
 
     name = property(lambda x: "gpu")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "all")
     requiredMetrics = property(lambda x: ["nvidia.gpuactive", "nvidia.memused"])
     optionalMetrics = property(lambda x: ["nvidia.memactive"])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(GpuUsage, self).__init__(job)
+    def __init__(self, job, config):
+        super(GpuUsage, self).__init__(job, config)
         self._data = {}
         self.statnames = None
 

--- a/src/supremm/plugins/GpuUsagePrometheus.py
+++ b/src/supremm/plugins/GpuUsagePrometheus.py
@@ -2,6 +2,7 @@
 """ Energy usage plugin - https://github.com/NVIDIA/gpu-monitoring-tools"""
 
 from supremm.plugin import PrometheusPlugin
+from supremm.errors import ProcessingError
 
 class GpuUsagePrometheus(PrometheusPlugin):
     """ Compute the power statistics for a job """
@@ -10,13 +11,49 @@ class GpuUsagePrometheus(PrometheusPlugin):
     metric_system = property(lambda x: "prometheus")
     requiredMetrics = property(lambda x: {
         'memused': {
-            'metric': 'DCGM_FI_DEV_FB_USED{{instance=~"^{node}.+"}} * 1024^2',
+            'metrics': [
+                '(DCGM_FI_DEV_FB_USED{{instance=~"^{node}.+"}} * 1024^2) * ON({host_label},gpu) {job_gpu_info}{{instance=~"^{node}.+",jobid="{jobid}"}}',
+                '(DCGM_FI_DEV_FB_USED{{instance=~"^{node}.+"}} * 1024^2) * ON(gpu) {job_gpu_info}{{instance=~"^{node}.+",jobid="{jobid}"}}',
+                'DCGM_FI_DEV_FB_USED{{instance=~"^{node}.+"}} * 1024^2',
+            ],
             'indom': 'gpu{gpu}',
         },
         'util': {
-            'metric': 'DCGM_FI_DEV_GPU_UTIL{{instance=~"^{node}.+"}}',
+            'metrics': [
+                'DCGM_FI_DEV_GPU_UTIL{{instance=~"^{node}.+"}} * ON({host_label},gpu) {job_gpu_info}{{instance=~"^{node}.+",jobid="{jobid}"}}',
+                'DCGM_FI_DEV_GPU_UTIL{{instance=~"^{node}.+"}} * ON(gpu) {job_gpu_info}{{instance=~"^{node}.+",jobid="{jobid}"}}',
+                'DCGM_FI_DEV_GPU_UTIL{{instance=~"^{node}.+"}}',
+            ],
             'indom': 'gpu{gpu}',
-        }
+        },
     })
     optionalMetrics = property(lambda x: {})
     derivedMetrics = property(lambda x: {})
+
+    def process(self, mdata):
+        for metricname, metric in self.allmetrics.items():
+            indom_label = metric.get('indom', None)
+            results = []
+            for query_metric in metric['metrics']:
+                if len(results) > 0:
+                    continue
+                query = query_metric.format(node=mdata.nodename, jobid=self._job.job_id, rate=self.rate, host_label=self.host_label, job_gpu_info=self.job_gpu_info)
+                data = self.query_range(query, mdata.start, mdata.end)
+                if data is None:
+                    self._error = ProcessingError.PROMETHEUS_QUERY_ERROR
+                    return None
+                results = data.get('data', {}).get('result', [])
+            for r in results:
+                m = r.get('metric', {})
+                device = indom_label.format(**m)
+                if device not in self._data:
+                    self._data[device] = {}
+                if metricname not in self._data[device]:
+                    self._data[device][metricname] = []
+                for v in r.get('values', []):
+                    ts = int(v[0])
+                    if ts <= (mdata.start + self.start_trim) or ts >= (mdata.end - self.end_trim):
+                        continue
+                    value = float(v[1])
+                    self._data[device][metricname].append(value)
+        return True

--- a/src/supremm/plugins/GpuUsagePrometheus.py
+++ b/src/supremm/plugins/GpuUsagePrometheus.py
@@ -9,8 +9,8 @@ class GpuUsagePrometheus(PrometheusPlugin):
     name = property(lambda x: "gpu")
     metric_system = property(lambda x: "prometheus")
     requiredMetrics = property(lambda x: {
-        'memutil': {
-            'metric': 'DCGM_FI_DEV_MEM_COPY_UTIL{{instance=~"^{node}.+"}}',
+        'memused': {
+            'metric': 'DCGM_FI_DEV_FB_USED{{instance=~"^{node}.+"}} * 1024^2',
             'indom': 'gpu{gpu}',
         },
         'util': {

--- a/src/supremm/plugins/GpuUsagePrometheus.py
+++ b/src/supremm/plugins/GpuUsagePrometheus.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+""" Energy usage plugin - https://github.com/NVIDIA/gpu-monitoring-tools"""
+
+from supremm.plugin import PrometheusPlugin
+
+class GpuUsagePrometheus(PrometheusPlugin):
+    """ Compute the power statistics for a job """
+
+    name = property(lambda x: "gpu")
+    metric_system = property(lambda x: "prometheus")
+    requiredMetrics = property(lambda x: {
+        'memutil': {
+            'metric': 'DCGM_FI_DEV_MEM_COPY_UTIL{{instance=~"^{node}.+"}}',
+            'indom': 'gpu{gpu}',
+        },
+        'util': {
+            'metric': 'DCGM_FI_DEV_GPU_UTIL{{instance=~"^{node}.+"}}',
+            'indom': 'gpu{gpu}',
+        }
+    })
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})

--- a/src/supremm/plugins/GpuUsageTimeseries.py
+++ b/src/supremm/plugins/GpuUsageTimeseries.py
@@ -10,13 +10,14 @@ class GpuUsageTimeseries(Plugin):
     """ Generate the CPU usage as a timeseries data """
 
     name = property(lambda x: "gpu_usage")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "timeseries")
     requiredMetrics = property(lambda x: ["nvidia.gpuactive"])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(GpuUsageTimeseries, self).__init__(job)
+    def __init__(self, job, config):
+        super(GpuUsageTimeseries, self).__init__(job, config)
         self._data = TimeseriesAccumulator(job.nodecount, self._job.walltime)
         self._hostdata = {}
         self._hostdevnames = {}

--- a/src/supremm/plugins/GpuUsageTimeseriesPrometheus.py
+++ b/src/supremm/plugins/GpuUsageTimeseriesPrometheus.py
@@ -41,6 +41,9 @@ class GpuUsageTimeseriesPrometheus(PrometheusTimeseriesNamePlugin):
                 if name not in self._names.values():
                     self._names[str(idx)] = name
                 for v in r.get('values', []):
+                    ts = int(v[0])
+                    if ts <= (mdata.start + self.start_trim) or ts >= (mdata.end - self.end_trim):
+                        continue
                     value = float(v[1])
                     if v[0] not in timeseries:
                         timeseries[v[0]] = []

--- a/src/supremm/plugins/GpuUsageTimeseriesPrometheus.py
+++ b/src/supremm/plugins/GpuUsageTimeseriesPrometheus.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+""" Block usage timerseries plugin - https://github.com/NVIDIA/gpu-monitoring-tools"""
+
+from supremm.plugin import PrometheusTimeseriesNamePlugin
+from supremm.subsample import TimeseriesAccumulator
+from supremm.errors import ProcessingError
+import numpy
+from collections import OrderedDict
+
+class GpuUsageTimeseriesPrometheus(PrometheusTimeseriesNamePlugin):
+    """ This plugin processes lots of metric that are all interested in the difference over the process """
+
+    name = property(lambda x: "gpu_usage")
+    metric_system = property(lambda x: "prometheus")
+    requiredMetrics = property(lambda x: {
+        'util': {
+            'metric': 'DCGM_FI_DEV_GPU_UTIL{{instance=~"^{node}.+"}}',
+            'timeseries_name': 'gpu{gpu}',
+        }
+    })
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})
+
+    def process(self, mdata):
+        timeseries = OrderedDict()
+        idx = 0
+        if mdata.nodeindex not in self._hostdata:
+            self._hostdata[mdata.nodeindex] = 1
+        for metricname, metric in self.allmetrics.items():
+            timeseries_name = metric['timeseries_name']
+            query = metric['metric'].format(node=mdata.nodename, jobid=self._job.job_id, rate=self.rate)
+            data = self.query_range(query, mdata.start, mdata.end)
+            if data is None:
+                self._error = ProcessingError.PROMETHEUS_QUERY_ERROR
+                return None
+            for r in data.get('data', {}).get('result', []):
+                labels = r.get('metric', {})
+                name = timeseries_name.format(**labels)
+                if str(idx) not in self._devicedata:
+                    self._devicedata[str(idx)] = TimeseriesAccumulator(self._job.nodecount, self._job.walltime)
+                if name not in self._names.values():
+                    self._names[str(idx)] = name
+                for v in r.get('values', []):
+                    value = float(v[1])
+                    if v[0] not in timeseries:
+                        timeseries[v[0]] = []
+                    timeseries[v[0]].append(value)
+                    self._devicedata[str(idx)].adddata(mdata.nodeindex, v[0], value)
+                idx += 1
+        for t, v in timeseries.items():
+            avg_usage = numpy.mean(v)
+            self._data.adddata(mdata.nodeindex, t, avg_usage)
+        return True

--- a/src/supremm/plugins/InfiniBand.py
+++ b/src/supremm/plugins/InfiniBand.py
@@ -6,6 +6,7 @@ class InfiniBand(DeviceBasedPlugin):
     """ This plugin processes lots of metric that are all interested in the difference over the process """
 
     name = property(lambda x: "infiniband")
+    metric_system = property(lambda x: "pcp")
     requiredMetrics = property(lambda x: [
         "infiniband.port.switch.in.bytes",
         "infiniband.port.switch.in.packets",

--- a/src/supremm/plugins/InfiniBandPrometheus.py
+++ b/src/supremm/plugins/InfiniBandPrometheus.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""https://github.com/prometheus/node_exporter"""
+
+from supremm.plugin import PrometheusPlugin
+
+class InfiniBandPrometheus(PrometheusPlugin):
+    """ This plugin processes lots of metric that are all interested in the difference over the process """
+
+    name = property(lambda x: "infiniband")
+    metric_system = property(lambda x: "prometheus")
+    requiredMetrics = property(lambda x: {
+        "switch-in-bytes": {
+            'metric': 'rate(node_infiniband_port_data_received_bytes_total{{instance=~"^{node}.+"}}[{rate}])',
+            'indom': '{device}:{port}',
+        },
+        "switch-out-bytes": {
+            'metric': 'rate(node_infiniband_port_data_transmitted_bytes_total{{instance=~"^{node}.+"}}[{rate}])',
+            'indom': '{device}:{port}',
+        },
+        "switch-in-packets": {
+            'metric': 'rate(node_infiniband_port_packets_received_total{{instance=~"^{node}.+"}}[{rate}])',
+            'indom': '{device}:{port}',
+        },
+        "switch-out-packets": {
+            'metric': 'rate(node_infiniband_port_packets_transmitted_total{{instance=~"^{node}.+"}}[{rate}])',
+            'indom': '{device}:{port}',
+        }
+    })
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})

--- a/src/supremm/plugins/InfiniBandTimeseries.py
+++ b/src/supremm/plugins/InfiniBandTimeseries.py
@@ -8,13 +8,14 @@ class InfiniBandTimeseries(RateConvertingTimeseriesPlugin):
     """ Generate the infiniband usage as a timeseries data """
 
     name = property(lambda x: "ib_lnet")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "timeseries")
     requiredMetrics = property(lambda x: ["infiniband.port.switch.in.bytes", "infiniband.port.switch.out.bytes"])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(InfiniBandTimeseries, self).__init__(job)
+    def __init__(self, job, config):
+        super(InfiniBandTimeseries, self).__init__(job, config)
 
     def computetimepoint(self, data):
         return (numpy.sum(data[0]) + numpy.sum(data[1])) / 1048576.0

--- a/src/supremm/plugins/InfiniBandTimeseriesPrometheus.py
+++ b/src/supremm/plugins/InfiniBandTimeseriesPrometheus.py
@@ -10,11 +10,11 @@ class InfiniBandTimeseriesPrometheus(PrometheusTimeseriesNamePlugin):
     metric_system = property(lambda x: "prometheus")
     requiredMetrics = property(lambda x: {
         "switch-in-bytes": {
-            'metric': 'rate(node_infiniband_port_data_received_bytes_total{{instance=~"^{node}.+"}}[{rate}])',
+            'metric': 'sum(rate(node_infiniband_port_data_received_bytes_total{{instance=~"^{node}.+"}}[{rate}]))',
             'timeseries_name': 'receive'
         },
         "switch-out-bytes": {
-            'metric': 'rate(node_infiniband_port_data_transmitted_bytes_total{{instance=~"^{node}.+"}}[{rate}])',
+            'metric': 'sum(rate(node_infiniband_port_data_transmitted_bytes_total{{instance=~"^{node}.+"}}[{rate}]))',
             'timeseries_name': 'transmit'
         },
     })

--- a/src/supremm/plugins/InfiniBandTimeseriesPrometheus.py
+++ b/src/supremm/plugins/InfiniBandTimeseriesPrometheus.py
@@ -6,15 +6,15 @@ from supremm.plugin import PrometheusTimeseriesNamePlugin
 class InfiniBandTimeseriesPrometheus(PrometheusTimeseriesNamePlugin):
     """ This plugin processes lots of metric that are all interested in the difference over the process """
 
-    name = property(lambda x: "infiniband")
+    name = property(lambda x: "ib_lnet")
     metric_system = property(lambda x: "prometheus")
     requiredMetrics = property(lambda x: {
         "switch-in-bytes": {
-            'metric': 'sum(rate(node_infiniband_port_data_received_bytes_total{{instance=~"^{node}.+"}}[{rate}]))',
+            'metric': 'sum(rate(node_infiniband_port_data_received_bytes_total{{instance=~"^{node}.+"}}[{rate}])) / 1024^2',
             'timeseries_name': 'receive'
         },
         "switch-out-bytes": {
-            'metric': 'sum(rate(node_infiniband_port_data_transmitted_bytes_total{{instance=~"^{node}.+"}}[{rate}]))',
+            'metric': 'sum(rate(node_infiniband_port_data_transmitted_bytes_total{{instance=~"^{node}.+"}}[{rate}])) / 1024^2',
             'timeseries_name': 'transmit'
         },
     })

--- a/src/supremm/plugins/InfiniBandTimeseriesPrometheus.py
+++ b/src/supremm/plugins/InfiniBandTimeseriesPrometheus.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+"""https://github.com/prometheus/node_exporter"""
+
+from supremm.plugin import PrometheusTimeseriesNamePlugin
+
+class InfiniBandTimeseriesPrometheus(PrometheusTimeseriesNamePlugin):
+    """ This plugin processes lots of metric that are all interested in the difference over the process """
+
+    name = property(lambda x: "infiniband")
+    metric_system = property(lambda x: "prometheus")
+    requiredMetrics = property(lambda x: {
+        "switch-in-bytes": {
+            'metric': 'rate(node_infiniband_port_data_received_bytes_total{{instance=~"^{node}.+"}}[{rate}])',
+            'timeseries_name': 'receive'
+        },
+        "switch-out-bytes": {
+            'metric': 'rate(node_infiniband_port_data_transmitted_bytes_total{{instance=~"^{node}.+"}}[{rate}])',
+            'timeseries_name': 'transmit'
+        },
+    })
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})

--- a/src/supremm/plugins/IpmiPower.py
+++ b/src/supremm/plugins/IpmiPower.py
@@ -11,13 +11,14 @@ class IpmiPower(Plugin):
     """ Compute the power statistics for a job """
 
     name = property(lambda x: "ipmi")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "all")
     requiredMetrics = property(lambda x: ["ipmi.dcmi.power"])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(IpmiPower, self).__init__(job)
+    def __init__(self, job, config):
+        super(IpmiPower, self).__init__(job, config)
         self._data = {}
 
     def process(self, nodemeta, timestamp, data, description):

--- a/src/supremm/plugins/IpmiPowerPrometheus.py
+++ b/src/supremm/plugins/IpmiPowerPrometheus.py
@@ -32,7 +32,9 @@ class IpmiPowerPrometheus(PrometheusPlugin):
                 return None
             for r in data.get('data', {}).get('result', []):
                 for v in r.get('values', []):
-                    ts = v[0]
+                    ts = int(v[0])
+                    if ts <= (mdata.start + self.start_trim) or ts >= (mdata.end - self.end_trim):
+                        continue
                     value = float(v[1])
                     self._data[mdata.nodeindex]['power'].append(value)
                     self._data[mdata.nodeindex]['energy'].add(ts, value)

--- a/src/supremm/plugins/IpmiPowerPrometheus.py
+++ b/src/supremm/plugins/IpmiPowerPrometheus.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+""" Energy usage plugin - https://github.com/soundcloud/ipmi_exporter"""
+
+from supremm.plugin import PrometheusPlugin
+from supremm.statistics import RollingStats, calculate_stats, Integrator
+from supremm.errors import ProcessingError
+import numpy
+
+class IpmiPowerPrometheus(PrometheusPlugin):
+    """ Compute the power statistics for a job """
+
+    name = property(lambda x: "ipmi")
+    metric_system = property(lambda x: "prometheus")
+    requiredMetrics = property(lambda x: {
+        'power': {
+            'metric': 'ipmi_dcmi_power_consumption_watts{{instance=~"^{node}.+"}}'
+        }
+    })
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})
+
+    def process(self, mdata):
+        self._data[mdata.nodeindex] = {
+            'power': RollingStats(),
+            'energy': Integrator(mdata.start)
+        }
+        for metricname, metric in self.allmetrics.items():
+            query = metric['metric'].format(node=mdata.nodename, rate=self.rate)
+            data = self.query(query, mdata.start, mdata.end)
+            if data is None:
+                self._error = ProcessingError.PROMETHEUS_QUERY_ERROR
+                return None
+            for r in data.get('data', {}).get('result', []):
+                for v in r.get('values', []):
+                    ts = v[0]
+                    value = float(v[1])
+                    self._data[mdata.nodeindex]['power'].append(value)
+                    self._data[mdata.nodeindex]['energy'].add(ts, value)
+        return True
+
+    def results(self):
+
+        meanpower = []
+        maxpower = []
+
+        energy = []
+        time_covered = 0
+
+        for pdata in self._data.itervalues():
+            if pdata['power'].count() > 0:
+                meanpower.append(pdata['power'].mean())
+                maxpower.append(pdata['power'].max)
+            energy.append(pdata['energy'].total)
+            time_covered += pdata['energy'].elapsed
+
+        total_energy = numpy.sum(energy)
+
+        if total_energy < numpy.finfo(numpy.float64).eps:
+            return {"error": ProcessingError.RAW_COUNTER_UNAVAILABLE}
+
+        if time_covered < 0.9 * self._job.nodecount * self._job.walltime:
+            return {"error": ProcessingError.INSUFFICIENT_DATA}
+
+        if not meanpower:
+            return {"error": ProcessingError.INSUFFICIENT_DATA}
+
+        energy_stats = calculate_stats(energy)
+        energy_stats['total'] = total_energy
+
+        return {
+            "power": {
+                "mean": calculate_stats(meanpower),
+                "max": calculate_stats(maxpower)
+            },
+            "energy": energy_stats
+        }

--- a/src/supremm/plugins/IpmiPowerPrometheus.py
+++ b/src/supremm/plugins/IpmiPowerPrometheus.py
@@ -26,7 +26,7 @@ class IpmiPowerPrometheus(PrometheusPlugin):
         }
         for metricname, metric in self.allmetrics.items():
             query = metric['metric'].format(node=mdata.nodename, rate=self.rate)
-            data = self.query(query, mdata.start, mdata.end)
+            data = self.query_range(query, mdata.start, mdata.end)
             if data is None:
                 self._error = ProcessingError.PROMETHEUS_QUERY_ERROR
                 return None

--- a/src/supremm/plugins/Lnet.py
+++ b/src/supremm/plugins/Lnet.py
@@ -9,13 +9,14 @@ class Lnet(Plugin):
     """ Compute the overall lnet usage for a job """
 
     name = property(lambda x: "lnet")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "firstlast")
     requiredMetrics = property(lambda x: ["lustre.lnet.drop_length", "lustre.lnet.recv_length", "lustre.lnet.send_length", "lustre.lnet.drop_count", "lustre.lnet.recv_count", "lustre.lnet.send_count"])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(Lnet, self).__init__(job)
+    def __init__(self, job, config):
+        super(Lnet, self).__init__(job, config)
         self._first = {}
         self._data = numpy.empty((job.nodecount, len(self.requiredMetrics)))
         self._hostidx = 0

--- a/src/supremm/plugins/LoadAvg.py
+++ b/src/supremm/plugins/LoadAvg.py
@@ -9,13 +9,14 @@ class LoadAvg(Plugin):
     """ Process the load average metrics """
 
     name = property(lambda x: "load1")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "all")
     requiredMetrics = property(lambda x: ["kernel.all.load"])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(LoadAvg, self).__init__(job)
+    def __init__(self, job, config):
+        super(LoadAvg, self).__init__(job, config)
         self._data = {}
 
     def process(self, nodemeta, timestamp, data, description):

--- a/src/supremm/plugins/LoadAvgPrometheus.py
+++ b/src/supremm/plugins/LoadAvgPrometheus.py
@@ -42,16 +42,16 @@ class LoadAvgPrometheus(PrometheusPlugin):
         meanvalpercore = []
         maxvalpercore = []
 
-        hostcpus = self._job.getdata('proc')['hostcpus']
+        hinv = self._job.getdata('hinv')
 
         for nodename, loaddata in self._data.iteritems():
             if loaddata.count() > 0:
                 meanval.append(loaddata.mean())
                 maxval.append(loaddata.max)
 
-                if hostcpus is not None and nodename in hostcpus:
-                    meanvalpercore.append(loaddata.mean() / hostcpus[nodename])
-                    maxvalpercore.append(loaddata.max / hostcpus[nodename])
+                if nodename in hinv:
+                    meanvalpercore.append(loaddata.mean() / hinv[nodename]['cores'])
+                    maxvalpercore.append(loaddata.max / hinv[nodename]['cores'])
 
         if len(meanval) == 0:
             return {"error": ProcessingError.INSUFFICIENT_DATA}

--- a/src/supremm/plugins/LoadAvgPrometheus.py
+++ b/src/supremm/plugins/LoadAvgPrometheus.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+""" Load Average plugin - https://github.com/prometheus/node_exporter"""
+
+from supremm.plugin import PrometheusPlugin
+from supremm.statistics import RollingStats, calculate_stats
+from supremm.errors import ProcessingError
+
+class LoadAvgPrometheus(PrometheusPlugin):
+    """ Process the load average metrics """
+
+    name = property(lambda x: "load1")
+    metric_system = property(lambda x: "prometheus")
+    requiredMetrics = property(lambda x: {
+        'load': {
+            'metric': 'node_load1{{instance=~"^{node}.+"}}'
+        }
+    })
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})
+
+    def process(self, mdata):
+        """ Computes the mean and max values of the load average for each node
+           optionally normalizes this data to be per core (if the core count is available)
+        """
+        self._data[mdata.nodename] = RollingStats()
+        for metricname, metric in self.allmetrics.items():
+            query = metric['metric'].format(node=mdata.nodename, rate=self.rate)
+            data = self.query_range(query, mdata.start, mdata.end)
+            if data is None:
+                self._error = ProcessingError.PROMETHEUS_QUERY_ERROR
+                return None
+            for r in data.get('data', {}).get('result', []):
+                for v in r.get('values', []):
+                    value = float(v[1])
+                    self._data[mdata.nodename].append(value)
+        return True
+
+    def results(self):
+
+        meanval = []
+        maxval = []
+        meanvalpercore = []
+        maxvalpercore = []
+
+        hostcpus = self._job.getdata('proc')['hostcpus']
+
+        for nodename, loaddata in self._data.iteritems():
+            if loaddata.count() > 0:
+                meanval.append(loaddata.mean())
+                maxval.append(loaddata.max)
+
+                if hostcpus is not None and nodename in hostcpus:
+                    meanvalpercore.append(loaddata.mean() / hostcpus[nodename])
+                    maxvalpercore.append(loaddata.max / hostcpus[nodename])
+
+        if len(meanval) == 0:
+            return {"error": ProcessingError.INSUFFICIENT_DATA}
+
+        results = {
+            "mean": calculate_stats(meanval),
+            "max": calculate_stats(maxval)
+        }
+
+        if len(meanvalpercore) > 0:
+            results['meanpercore'] = calculate_stats(meanvalpercore)
+            results['maxpercore'] = calculate_stats(maxvalpercore)
+
+        return results
+

--- a/src/supremm/plugins/LoadAvgPrometheus.py
+++ b/src/supremm/plugins/LoadAvgPrometheus.py
@@ -50,6 +50,8 @@ class LoadAvgPrometheus(PrometheusPlugin):
                 maxval.append(loaddata.max)
 
                 if nodename in hinv:
+                    if 'error' in hinv[nodename]:
+                        continue
                     meanvalpercore.append(loaddata.mean() / hinv[nodename]['cores'])
                     maxvalpercore.append(loaddata.max / hinv[nodename]['cores'])
 

--- a/src/supremm/plugins/LoadAvgPrometheus.py
+++ b/src/supremm/plugins/LoadAvgPrometheus.py
@@ -31,6 +31,9 @@ class LoadAvgPrometheus(PrometheusPlugin):
                 return None
             for r in data.get('data', {}).get('result', []):
                 for v in r.get('values', []):
+                    ts = int(v[0])
+                    if ts <= (mdata.start + self.start_trim) or ts >= (mdata.end - self.end_trim):
+                        continue
                     value = float(v[1])
                     self._data[mdata.nodename].append(value)
         return True

--- a/src/supremm/plugins/Lustre.py
+++ b/src/supremm/plugins/Lustre.py
@@ -6,6 +6,7 @@ class Lustre(DeviceBasedPlugin):
     """ This plugin processes lots of metric that are all interested in the difference over the process """
 
     name = property(lambda x: "lustre")
+    metric_system = property(lambda x: "pcp")
     requiredMetrics = property(lambda x: [
         "lustre.llite.read_bytes.total",
         "lustre.llite.write_bytes.total"

--- a/src/supremm/plugins/LustreTimeseries.py
+++ b/src/supremm/plugins/LustreTimeseries.py
@@ -8,12 +8,13 @@ class LustreTimeseries(RateConvertingTimeseriesPlugin):
     """ Generate the Lustre usage as a timeseries data """
 
     name = property(lambda x: "lnet")
+    metric_system = property(lambda x: "pcp")
     requiredMetrics = property(lambda x: ["lustre.llite.read_bytes.total", "lustre.llite.write_bytes.total"])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(LustreTimeseries, self).__init__(job)
+    def __init__(self, job, config):
+        super(LustreTimeseries, self).__init__(job, config)
 
     def computetimepoint(self, data):
         return (numpy.sum(data[0]) + numpy.sum(data[1])) / 1048576.0

--- a/src/supremm/plugins/MemBwTimeseries.py
+++ b/src/supremm/plugins/MemBwTimeseries.py
@@ -32,13 +32,14 @@ class MemBwTimeseries(Plugin):
     """ Generate the memory bandwidth as timeseries data """
 
     name = property(lambda x: "membw")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "timeseries")
     requiredMetrics = property(lambda x: [SNB_METRICS, IVB_METRICS, NHM_METRICS])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(MemBwTimeseries, self).__init__(job)
+    def __init__(self, job, config):
+        super(MemBwTimeseries, self).__init__(job, config)
         self._data = TimeseriesAccumulator(job.nodecount, self._job.walltime)
         self._hostdata = {}
         self._hostdevnames = {}

--- a/src/supremm/plugins/MemUsageTimeseries.py
+++ b/src/supremm/plugins/MemUsageTimeseries.py
@@ -10,13 +10,14 @@ class MemUsageTimeseries(Plugin):
     """ Generate the CPU usage as a timeseries data """
 
     name = property(lambda x: "memused_minus_diskcache")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "timeseries")
     requiredMetrics = property(lambda x: ["mem.numa.util.used", "mem.numa.util.filePages", "mem.numa.util.slab"])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(MemUsageTimeseries, self).__init__(job)
+    def __init__(self, job, config):
+        super(MemUsageTimeseries, self).__init__(job, config)
         self._data = TimeseriesAccumulator(job.nodecount, self._job.walltime)
         self._hostdata = {}
         self._hostdevnames = {}

--- a/src/supremm/plugins/MemUsageTimeseriesPrometheus.py
+++ b/src/supremm/plugins/MemUsageTimeseriesPrometheus.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+""" Timeseries generator module - https://github.com/prometheus/node_exporter"""
+
+from supremm.plugin import PrometheusTimeseriesPlugin
+from supremm.subsample import TimeseriesAccumulator
+import numpy
+from collections import Counter
+
+class MemUsageTimeseriesPrometheus(PrometheusTimeseriesPlugin):
+    """ Generate the CPU usage as a timeseries data """
+
+    name = property(lambda x: "memused_minus_diskcache")
+    metric_system = property(lambda x: "prometheus")
+    requiredMetrics = property(lambda x: {
+        'used_minus_cache': {
+            'metric': """node_memory_MemTotal_bytes{{instance=~"^{node}.+"}}
+                - node_memory_MemFree_bytes{{instance=~"^{node}.+"}}
+                - node_memory_Cached_bytes{{instance=~"^{node}.+"}}
+                - node_memory_Slab_bytes{{instance=~"^{node}.+"}}""",
+        }
+    })
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})

--- a/src/supremm/plugins/MemUsageTimeseriesPrometheus.py
+++ b/src/supremm/plugins/MemUsageTimeseriesPrometheus.py
@@ -2,9 +2,6 @@
 """ Timeseries generator module - https://github.com/prometheus/node_exporter"""
 
 from supremm.plugin import PrometheusTimeseriesPlugin
-from supremm.subsample import TimeseriesAccumulator
-import numpy
-from collections import Counter
 
 class MemUsageTimeseriesPrometheus(PrometheusTimeseriesPlugin):
     """ Generate the CPU usage as a timeseries data """

--- a/src/supremm/plugins/MemoryUsage.py
+++ b/src/supremm/plugins/MemoryUsage.py
@@ -9,13 +9,14 @@ class MemoryUsage(Plugin):
     """ Compute the overall memory usage for a job """
 
     name = property(lambda x: "memory")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "all")
     requiredMetrics = property(lambda x: ["mem.numa.util.used", "mem.numa.util.filePages", "mem.numa.util.slab", "kernel.percpu.cpu.user"])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(MemoryUsage, self).__init__(job)
+    def __init__(self, job, config):
+        super(MemoryUsage, self).__init__(job, config)
         self._data = {}
         self._hostcpucounts = {}
 

--- a/src/supremm/plugins/MemoryUsagePrometheus.py
+++ b/src/supremm/plugins/MemoryUsagePrometheus.py
@@ -49,17 +49,17 @@ class MemoryUsagePrometheus(PrometheusPlugin):
         return True
 
     def results(self):
-        hostcpus = self._job.getdata('proc')['hostcpus']
+        hinv = self._job.getdata('hinv')
         memused = []
         memusedminus = []
 
         for nodename, memdata in self._data.iteritems():
-            if nodename not in hostcpus:
+            if nodename not in hinv:
                 return {"error": ProcessingError.INSUFFICIENT_HOSTDATA}
             if memdata['used'].count() > 0:
-                memused.append(memdata['used'].mean() / hostcpus[nodename])
+                memused.append(memdata['used'].mean() / hinv[nodename]['cores'])
             if memdata['used_minus_cache'].count() > 0:
-                memusedminus.append(memdata['used_minus_cache'].mean() / hostcpus[nodename])
+                memusedminus.append(memdata['used_minus_cache'].mean() / hinv[nodename]['cores'])
 
         if len(memused) == 0:
             return {"error": ProcessingError.INSUFFICIENT_DATA}

--- a/src/supremm/plugins/MemoryUsagePrometheus.py
+++ b/src/supremm/plugins/MemoryUsagePrometheus.py
@@ -56,6 +56,8 @@ class MemoryUsagePrometheus(PrometheusPlugin):
         for nodename, memdata in self._data.iteritems():
             if nodename not in hinv:
                 return {"error": ProcessingError.INSUFFICIENT_HOSTDATA}
+            if 'error' in hinv[nodename]:
+                return {"error": ProcessingError.INSUFFICIENT_HOSTDATA}
             if memdata['used'].count() > 0:
                 memused.append(memdata['used'].mean() / hinv[nodename]['cores'])
             if memdata['used_minus_cache'].count() > 0:

--- a/src/supremm/plugins/MemoryUsagePrometheus.py
+++ b/src/supremm/plugins/MemoryUsagePrometheus.py
@@ -15,7 +15,7 @@ class MemoryUsagePrometheus(PrometheusPlugin):
             'metric': 'node_memory_MemTotal_bytes{{instance=~"^{node}.+"}} - node_memory_MemFree_bytes{{instance=~"^{node}.+"}}',
         },
         'used_minus_cache': {
-            'metric': """(node_memory_MemTotal_bytes{{instance=~"^{node}.+"}}
+            'metric': """node_memory_MemTotal_bytes{{instance=~"^{node}.+"}}
                 - node_memory_MemFree_bytes{{instance=~"^{node}.+"}}
                 - node_memory_Cached_bytes{{instance=~"^{node}.+"}}
                 - node_memory_Slab_bytes{{instance=~"^{node}.+"}}""",

--- a/src/supremm/plugins/MemoryUsagePrometheus.py
+++ b/src/supremm/plugins/MemoryUsagePrometheus.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+""" Memory usage plugin - https://github.com/prometheus/node_exporter"""
+
+from supremm.plugin import PrometheusPlugin
+from supremm.statistics import RollingStats, calculate_stats
+from supremm.errors import ProcessingError
+
+class MemoryUsagePrometheus(PrometheusPlugin):
+    """ Compute the overall memory usage for a job """
+
+    name = property(lambda x: "memory")
+    metric_system = property(lambda x: "prometheus")
+    requiredMetrics = property(lambda x: {
+        'used': {
+            'metric': 'node_memory_MemTotal_bytes{{instance=~"^{node}.+"}} - node_memory_MemFree_bytes{{instance=~"^{node}.+"}}',
+        },
+        'used_minus_cache': {
+            'metric': """(node_memory_MemTotal_bytes{{instance=~"^{node}.+"}}
+                - node_memory_MemFree_bytes{{instance=~"^{node}.+"}}
+                - node_memory_Cached_bytes{{instance=~"^{node}.+"}}
+                - node_memory_Slab_bytes{{instance=~"^{node}.+"}}""",
+        }
+    })
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})
+
+    def process(self, mdata):
+        """ Memory statistics are the aritmetic mean of all values except the
+            first and last rather than storing all of the meory measurements for
+            the job, we use the RollingStats() class to keep track of the mean
+            values. Since we don't know which data point is the last one, we update
+            the RollingStats with the value from the previous timestep at each timestep.  
+        """
+        self._data[mdata.nodename] = {
+            'used': RollingStats(),
+            'used_minus_cache': RollingStats(),
+        }
+        for metricname, metric in self.allmetrics.items():
+            query = metric['metric'].format(node=mdata.nodename, rate=self.rate)
+            data = self.query_range(query, mdata.start, mdata.end)
+            if data is None:
+                self._error = ProcessingError.PROMETHEUS_QUERY_ERROR
+                return None
+            for r in data.get('data', {}).get('result', []):
+                for v in r.get('values', []):
+                    value = float(v[1])
+                    self._data[mdata.nodename][metricname].append(value)
+
+        return True
+
+    def results(self):
+        hostcpus = self._job.getdata('proc')['hostcpus']
+        memused = []
+        memusedminus = []
+
+        for nodename, memdata in self._data.iteritems():
+            if nodename not in hostcpus:
+                return {"error": ProcessingError.INSUFFICIENT_HOSTDATA}
+            if memdata['used'].count() > 0:
+                memused.append(memdata['used'].mean() / hostcpus[nodename])
+            if memdata['used_minus_cache'].count() > 0:
+                memusedminus.append(memdata['used_minus_cache'].mean() / hostcpus[nodename])
+
+        if len(memused) == 0:
+            return {"error": ProcessingError.INSUFFICIENT_DATA}
+
+        return {"used": calculate_stats(memused), "used_minus_cache": calculate_stats(memusedminus)}

--- a/src/supremm/plugins/MemoryUsagePrometheus.py
+++ b/src/supremm/plugins/MemoryUsagePrometheus.py
@@ -12,13 +12,13 @@ class MemoryUsagePrometheus(PrometheusPlugin):
     metric_system = property(lambda x: "prometheus")
     requiredMetrics = property(lambda x: {
         'used': {
-            'metric': 'node_memory_MemTotal_bytes{{instance=~"^{node}.+"}} - node_memory_MemFree_bytes{{instance=~"^{node}.+"}}',
+            'metric': '(node_memory_MemTotal_bytes{{instance=~"^{node}.+"}} - node_memory_MemFree_bytes{{instance=~"^{node}.+"}}) / 1024',
         },
         'used_minus_cache': {
-            'metric': """node_memory_MemTotal_bytes{{instance=~"^{node}.+"}}
+            'metric': """(node_memory_MemTotal_bytes{{instance=~"^{node}.+"}}
                 - node_memory_MemFree_bytes{{instance=~"^{node}.+"}}
                 - node_memory_Cached_bytes{{instance=~"^{node}.+"}}
-                - node_memory_Slab_bytes{{instance=~"^{node}.+"}}""",
+                - node_memory_Slab_bytes{{instance=~"^{node}.+"}}) / 1024""",
         }
     })
     optionalMetrics = property(lambda x: {})

--- a/src/supremm/plugins/MemoryUsagePrometheus.py
+++ b/src/supremm/plugins/MemoryUsagePrometheus.py
@@ -43,6 +43,9 @@ class MemoryUsagePrometheus(PrometheusPlugin):
                 return None
             for r in data.get('data', {}).get('result', []):
                 for v in r.get('values', []):
+                    ts = int(v[0])
+                    if ts <= (mdata.start + self.start_trim) or ts >= (mdata.end - self.end_trim):
+                        continue
                     value = float(v[1])
                     self._data[mdata.nodename][metricname].append(value)
 

--- a/src/supremm/plugins/Network.py
+++ b/src/supremm/plugins/Network.py
@@ -6,6 +6,7 @@ class Network(DeviceBasedPlugin):
     """ This plugin processes lots of metric that are all interested in the difference over the process """
 
     name = property(lambda x: "network")
+    metric_system = property(lambda x: "pcp")
     requiredMetrics = property(lambda x: [
         "network.interface.in.bytes",
         "network.interface.out.bytes",

--- a/src/supremm/plugins/NetworkPrometheus.py
+++ b/src/supremm/plugins/NetworkPrometheus.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""https://github.com/prometheus/node_exporter"""
+
+from supremm.plugin import PrometheusPlugin
+
+class NetworkPrometheus(PrometheusPlugin):
+    """ This plugin processes lots of metric that are all interested in the difference over the process """
+
+    name = property(lambda x: "network")
+    metric_system = property(lambda x: "prometheus")
+    requiredMetrics = property(lambda x: {
+        "in-bytes": {
+            'metric': 'rate(node_network_receive_bytes_total{{instance=~"^{node}.+",device!="lo"}}[{rate}])',
+            'indom': '{device}',
+        },
+        "out-bytes": {
+            'metric': 'rate(node_network_transmit_bytes_total{{instance=~"^{node}.+",device!="lo"}}[{rate}])',
+            'indom': '{device}',
+        },
+        "in-packets": {
+            'metric': 'rate(node_network_receive_packets_total{{instance=~"^{node}.+",device!="lo"}}[{rate}])',
+            'indom': '{device}',
+        },
+        "out-packets": {
+            'metric': 'rate(node_network_transmit_packets_total{{instance=~"^{node}.+",device!="lo"}}[{rate}])',
+            'indom': '{device}',
+        }
+    })
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})

--- a/src/supremm/plugins/Nfs.py
+++ b/src/supremm/plugins/Nfs.py
@@ -6,6 +6,7 @@ class Nfs(DeviceBasedPlugin):
     """ Generate usage statistics for NFS clients """
 
     name = property(lambda x: "nfs")
+    metric_system = property(lambda x: "pcp")
     requiredMetrics = property(lambda x: [
         "nfsclient.bytes.read.normal",
         "nfsclient.bytes.read.direct",

--- a/src/supremm/plugins/NfsPrometheus.py
+++ b/src/supremm/plugins/NfsPrometheus.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+"""https://github.com/prometheus/node_exporter"""
+
+from supremm.plugin import PrometheusPlugin
+
+class NfsPrometheus(PrometheusPlugin):
+    """ Generate usage statistics for NFS clients """
+
+    name = property(lambda x: "nfs")
+    metric_system = property(lambda x: "prometheus")
+    requiredMetrics = property(lambda x: {
+        "read": {
+            'metric': 'rate(node_mountstats_nfs_total_read_bytes_total{{instance=~"^{node}.+"}}[{rate}])',
+            'indom': '{export}',
+        },
+        "write": {
+            'metric': 'rate(node_mountstats_nfs_total_write_bytes_total{{instance=~"^{node}.+"}}[{rate}])',
+            'indom': '{export}',
+        },
+    })
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})

--- a/src/supremm/plugins/NfsTimeseries.py
+++ b/src/supremm/plugins/NfsTimeseries.py
@@ -8,6 +8,7 @@ class NfsTimeseries(RateConvertingTimeseriesPlugin):
     """ Generate timeseries summary for NFS usage data """
 
     name = property(lambda x: "nfs")
+    metric_system = property(lambda x: "pcp")
     requiredMetrics = property(lambda x: ["nfsclient.bytes.read.normal",
                                           "nfsclient.bytes.read.direct",
                                           "nfsclient.bytes.read.server",
@@ -17,8 +18,8 @@ class NfsTimeseries(RateConvertingTimeseriesPlugin):
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(NfsTimeseries, self).__init__(job)
+    def __init__(self, job, config):
+        super(NfsTimeseries, self).__init__(job, config)
 
     def computetimepoint(self, data):
         try:

--- a/src/supremm/plugins/NfsTimeseriesPrometheus.py
+++ b/src/supremm/plugins/NfsTimeseriesPrometheus.py
@@ -10,11 +10,11 @@ class NfsTimeseriesPrometheus(PrometheusTimeseriesNamePlugin):
     metric_system = property(lambda x: "prometheus")
     requiredMetrics = property(lambda x: {
         "read": {
-            'metric': 'sum(rate(node_mountstats_nfs_total_read_bytes_total{{instance=~"^{node}.+"}}[{rate}]))',
+            'metric': 'sum(rate(node_mountstats_nfs_total_read_bytes_total{{instance=~"^{node}.+"}}[{rate}])) / 1024^2',
             'timeseries_name': 'read',
         },
         "write": {
-            'metric': 'sum(rate(node_mountstats_nfs_total_write_bytes_total{{instance=~"^{node}.+"}}[{rate}]))',
+            'metric': 'sum(rate(node_mountstats_nfs_total_write_bytes_total{{instance=~"^{node}.+"}}[{rate}])) / 1024^2',
             'timeseries_name': 'write',
         },
     })

--- a/src/supremm/plugins/NfsTimeseriesPrometheus.py
+++ b/src/supremm/plugins/NfsTimeseriesPrometheus.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+""" Timeseries generator module """
+
+from supremm.plugin import PrometheusTimeseriesNamePlugin
+
+class NfsTimeseriesPrometheus(PrometheusTimeseriesNamePlugin):
+    """ Generate timeseries summary for NFS usage data """
+
+    name = property(lambda x: "nfs")
+    metric_system = property(lambda x: "prometheus")
+    requiredMetrics = property(lambda x: {
+        "read": {
+            'metric': 'sum(rate(node_mountstats_nfs_total_read_bytes_total{{instance=~"^{node}.+"}}[{rate}]))',
+            'timeseries_name': 'read',
+        },
+        "write": {
+            'metric': 'sum(rate(node_mountstats_nfs_total_write_bytes_total{{instance=~"^{node}.+"}}[{rate}]))',
+            'timeseries_name': 'write',
+        },
+    })
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})

--- a/src/supremm/plugins/NodeMemoryUsage.py
+++ b/src/supremm/plugins/NodeMemoryUsage.py
@@ -9,13 +9,14 @@ class NodeMemoryUsage(Plugin):
     """ Compute the overall memory usage for a job """
 
     name = property(lambda x: "nodememory")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "all")
     requiredMetrics = property(lambda x: [["mem.freemem", "mem.physmem"], ["mem.util.free", "hinv.physmem", "mem.util.cached"]])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(NodeMemoryUsage, self).__init__(job)
+    def __init__(self, job, config):
+        super(NodeMemoryUsage, self).__init__(job, config)
         self._data = {}
 
     def process(self, nodemeta, timestamp, data, description):

--- a/src/supremm/plugins/PowerUsageTimeseries.py
+++ b/src/supremm/plugins/PowerUsageTimeseries.py
@@ -12,13 +12,14 @@ class PowerUsageTimeseries(Plugin):
     """ Generate the Power usage as a timeseries data """
 
     name = property(lambda x: "power")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "timeseries")
     requiredMetrics = property(lambda x: ["ipmi.dcmi.power"])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(PowerUsageTimeseries, self).__init__(job)
+    def __init__(self, job, config):
+        super(PowerUsageTimeseries, self).__init__(job, config)
         self._data = TimeseriesAccumulator(job.nodecount, self._job.walltime)
         self._hostdata = {}
 

--- a/src/supremm/plugins/PowerUsageTimeseriesPrometheus.py
+++ b/src/supremm/plugins/PowerUsageTimeseriesPrometheus.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+""" Timeseries generator module - https://github.com/soundcloud/ipmi_exporter"""
+
+from supremm.plugin import PrometheusTimeseriesPlugin
+
+class PowerUsageTimeseriesPrometheus(PrometheusTimeseriesPlugin):
+    """ Generate the Power usage as a timeseries data """
+
+    name = property(lambda x: "power")
+    metric_system = property(lambda x: "prometheus")
+    requiredMetrics = property(lambda x: {
+        'power': {
+            'metric': 'ipmi_dcmi_power_consumption_watts{{instance=~"^{node}.+"}}',
+        }
+    })
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})

--- a/src/supremm/plugins/SimdInsTimeseries.py
+++ b/src/supremm/plugins/SimdInsTimeseries.py
@@ -21,13 +21,14 @@ class SimdInsTimeseries(Plugin):
     """ Generate the CPU usage as a timeseries data """
 
     name = property(lambda x: "simdins")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "timeseries")
     requiredMetrics = property(lambda x: [SNB_METRICS, NHM_METRICS, INTERLAGOS_METRICS])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(SimdInsTimeseries, self).__init__(job)
+    def __init__(self, job, config):
+        super(SimdInsTimeseries, self).__init__(job, config)
         self._data = TimeseriesAccumulator(job.nodecount, self._job.walltime)
         self._hostdata = {}
         self._hostdevnames = {}

--- a/src/supremm/plugins/TaccCatastrophe.py
+++ b/src/supremm/plugins/TaccCatastrophe.py
@@ -10,13 +10,14 @@ class TaccCatastrophe(Plugin):
         tacc_stats project """
 
     name = property(lambda x: "catastrophe")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "all")
     requiredMetrics = property(lambda x: [ ["taccstats_perfevent.hwcounters.MEM_LOAD_RETIRED_L1D_HIT.value"], ["taccstats_perfevent.hwcounters.L1D_REPLACEMENT.value"] ])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(TaccCatastrophe, self).__init__(job)
+    def __init__(self, job, config):
+        super(TaccCatastrophe, self).__init__(job, config)
         self._data = {}
         self._values = {}
 

--- a/src/supremm/plugins/TaccPerfCounters.py
+++ b/src/supremm/plugins/TaccPerfCounters.py
@@ -21,13 +21,14 @@ NHM_METRICS = ["taccstats_perfevent.hwcounters.UNHALTED_REFERENCE_CYCLES.value",
 class TaccPerfCounters(Plugin):
     """ Compute various performance counter derived metrics """
     name = property(lambda x: "cpuperf")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "all")
     requiredMetrics = property(lambda x: [SNB_METRICS, NHM_METRICS])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(TaccPerfCounters, self).__init__(job)
+    def __init__(self, job, config):
+        super(TaccPerfCounters, self).__init__(job, config)
         self._last = {}
         self._data = {}
         self._totalcores = 0

--- a/src/supremm/plugins/TaccUncoreCounters.py
+++ b/src/supremm/plugins/TaccUncoreCounters.py
@@ -13,13 +13,14 @@ class TaccUncoreCounters(Plugin):
     """ Compute various uncore performance counter derived metrics """
 
     name = property(lambda x: "uncperf")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "all")
     requiredMetrics = property(lambda x: TACC_NHM_METRICS)
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(TaccUncoreCounters, self).__init__(job)
+    def __init__(self, job, config):
+        super(TaccUncoreCounters, self).__init__(job, config)
         self._last = {}
         self._data = {}
         self._error = None

--- a/src/supremm/plugins/TimeseriesPatternsGpfs.py
+++ b/src/supremm/plugins/TimeseriesPatternsGpfs.py
@@ -5,6 +5,7 @@ from supremm.TimeseriesPatterns import TimeseriesPatterns
 class TimeseriesPatternsGpfs(TimeseriesPatterns):
     requiredMetrics = property(lambda self: ["gpfs.fsios.read_bytes", "gpfs.fsios.write_bytes"])
     name = property(lambda self: "timeseries_patterns_gpfs")
+    metric_system = property(lambda x: "pcp")
 
-    def __init__(self, job):
-        super(TimeseriesPatternsGpfs, self).__init__(job)
+    def __init__(self, job, config):
+        super(TimeseriesPatternsGpfs, self).__init__(job, config)

--- a/src/supremm/plugins/TotalMemUsageTimeseries.py
+++ b/src/supremm/plugins/TotalMemUsageTimeseries.py
@@ -10,13 +10,14 @@ class TotalMemUsageTimeseries(Plugin):
     """ Generate the CPU usage as a timeseries data """
 
     name = property(lambda x: "memused")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "timeseries")
     requiredMetrics = property(lambda x: ["mem.numa.util.used"])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(TotalMemUsageTimeseries, self).__init__(job)
+    def __init__(self, job, config):
+        super(TotalMemUsageTimeseries, self).__init__(job, config)
         self._data = TimeseriesAccumulator(job.nodecount, self._job.walltime)
         self._hostdata = {}
         self._hostdevnames = {}

--- a/src/supremm/plugins/UncoreCounters.py
+++ b/src/supremm/plugins/UncoreCounters.py
@@ -33,13 +33,14 @@ class UncoreCounters(Plugin):
     """ Compute various uncore performance counter derived metrics """
 
     name = property(lambda x: "uncperf")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "firstlast")
     requiredMetrics = property(lambda x: [SNB_METRICS, IVB_METRICS, NHM_METRICS, INTERLAGOS_METRICS])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(UncoreCounters, self).__init__(job)
+    def __init__(self, job, config):
+        super(UncoreCounters, self).__init__(job, config)
         self._first = {}
         self._data = {}
         self._error = None

--- a/src/supremm/preprocessors/HardwareInventory.py
+++ b/src/supremm/preprocessors/HardwareInventory.py
@@ -10,13 +10,14 @@ class HardwareInventory(PreProcessor):
     """
 
     name = property(lambda x: "hinv")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "timeseries")
     requiredMetrics = property(lambda x: [["kernel.percpu.cpu.user"], ["hinv.ncpu"]])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(HardwareInventory, self).__init__(job)
+    def __init__(self, job, config):
+        super(HardwareInventory, self).__init__(job, config)
         self.hostname = None
         self.corecount = None
         self.data = {}

--- a/src/supremm/preprocessors/HardwareInventoryPrometheus.py
+++ b/src/supremm/preprocessors/HardwareInventoryPrometheus.py
@@ -57,6 +57,8 @@ class HardwareInventoryPrometheus(PrometheusPlugin):
     def results(self):
         if self._error != None:
             return {"error": self._error}
+        if len(self.cores) != self._job.nodecount:
+            return {"error": ProcessingError.INSUFFICIENT_HOSTDATA}
 
         return {"cores": calculate_stats(self.cores)}
 

--- a/src/supremm/preprocessors/HardwareInventoryPrometheus.py
+++ b/src/supremm/preprocessors/HardwareInventoryPrometheus.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+""" hardware inventory pre-processor - https://github.com/prometheus/node_exporter"""
+
+from supremm.plugin import PrometheusPlugin
+from supremm.statistics import calculate_stats
+from supremm.errors import ProcessingError
+
+class HardwareInventoryPrometheus(PrometheusPlugin):
+    """ Parse and analyse hardware inventory information. Currently
+        grabs the number of CPU cores for each host.
+    """
+
+    name = property(lambda x: "hinv")
+    metric_system = property(lambda x: "prometheus")
+    requiredMetrics = property(lambda x: {
+        'ncpus': {
+            'metric': 'count by(instance) (node_cpu_info{{instance=~"^{node}.+"}})'
+        }
+    })
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})
+
+    def __init__(self, job, config):
+        super(HardwareInventoryPrometheus, self).__init__(job, config)
+        self.hostname = None
+        self.corecount = None
+        self.data = {}
+        self.cores = []
+
+    def hoststart(self, hostname):
+        self.hostname = hostname
+        self.data[hostname] = {"error": ProcessingError.RAW_COUNTER_UNAVAILABLE}
+
+    def process(self, mdata):
+        for metricname, metric in self.allmetrics.items():
+            query = metric['metric'].format(node=mdata.nodename)
+            data = self.query(query, mdata.start)
+            if data is None:
+                self._error = ProcessingError.PROMETHEUS_QUERY_ERROR
+                return None
+            for r in data.get('data', {}).get('result', []):
+                if metricname == 'ncpus':
+                    value = r.get('value', [None, "0"])[1]
+                    self.corecount = float(value)
+        return True
+
+    def hostend(self):
+        if self.corecount is not None and self.corecount != 0:
+            self.data[self.hostname] = {'cores': self.corecount}
+            self.cores.append(self.corecount)
+
+        self.corecount = None
+        self.hostname = None
+
+        self._job.adddata(self.name, self.data)
+
+    def results(self):
+        if self._error != None:
+            return {"error": self._error}
+
+        return {"cores": calculate_stats(self.cores)}
+

--- a/src/supremm/preprocessors/PerfEvent.py
+++ b/src/supremm/preprocessors/PerfEvent.py
@@ -11,13 +11,14 @@ class PerfEvent(PreProcessor):
     """
 
     name = property(lambda x: "perf")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "timeseries")
     requiredMetrics = property(lambda x: ["perfevent.active"])
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(PerfEvent, self).__init__(job)
+    def __init__(self, job, config):
+        super(PerfEvent, self).__init__(job, config)
         self.perfactive = None
 
     def hoststart(self, hostname):

--- a/src/supremm/preprocessors/Proc.py
+++ b/src/supremm/preprocessors/Proc.py
@@ -19,6 +19,7 @@ class Proc(PreProcessor):
     """
 
     name = property(lambda x: "proc")
+    metric_system = property(lambda x: "pcp")
     mode = property(lambda x: "timeseries")
     requiredMetrics = property(lambda x: [
         ["proc.psinfo.cpusallowed",
@@ -32,8 +33,8 @@ class Proc(PreProcessor):
     optionalMetrics = property(lambda x: ["cgroup.cpuset.cpus"])
     derivedMetrics = property(lambda x: [])
 
-    def __init__(self, job):
-        super(Proc, self).__init__(job)
+    def __init__(self, job, config):
+        super(Proc, self).__init__(job, config)
 
         self.cgrouppath = None
         self.expectedcgroup = None

--- a/src/supremm/preprocessors/ProcPrometheus.py
+++ b/src/supremm/preprocessors/ProcPrometheus.py
@@ -63,7 +63,6 @@ class ProcPrometheus(PrometheusPlugin):
                 elif metricname == 'processes':
                     execname = m.get('exec', None)
                     if execname is None:
-                        self.output['procDump']['constrained'] = {"error": ProcessingError.RAW_COUNTER_UNAVAILABLE}
                         continue
                     if execname not in self.output['procDump']['constrained']:
                         self.output['procDump']['constrained'].append(execname)

--- a/src/supremm/preprocessors/ProcPrometheus.py
+++ b/src/supremm/preprocessors/ProcPrometheus.py
@@ -18,6 +18,9 @@ class ProcPrometheus(PrometheusPlugin):
         'cpusallowed': {
             'metric': 'cgroup_cpu_info{{instance=~"^{node}.+"}} * on(cgroup, instance) group_left(jobid) cgroup_info{{instance=~"^{node}.+",jobid="{jobid}"}}',
         },
+        'gpusallowed': {
+            'metric': '{job_gpu_info}{{instance=~"^{node}.+",jobid="{jobid}"}}',
+        },
         'processes': {
             'metric': 'cgroup_process_exec_count{{instance=~"^{node}.+"}} * on(cgroup, instance) group_left(jobid) cgroup_info{{instance=~"^{node}.+",jobid="{jobid}"}}',
         },
@@ -30,25 +33,31 @@ class ProcPrometheus(PrometheusPlugin):
         super(ProcPrometheus, self).__init__(job, config)
 
         self.cpusallowed = None
+        self.gpusallowed = None
         self.hostname = None
-        self.output = {"procDump": {"constrained": [], "unconstrained": []}, "cpusallowed": {}}
+        self.output = {"procDump": {"constrained": [], "unconstrained": []}, "cpusallowed": {}, "gpusallowed": {}}
 
     def hoststart(self, hostname):
         self.hostname = hostname
         self.output['cpusallowed'][hostname] = {"error": ProcessingError.RAW_COUNTER_UNAVAILABLE}
+        self.output['gpusallowed'][hostname] = {"error": ProcessingError.RAW_COUNTER_UNAVAILABLE}
 
     def hostend(self):
         if self.cpusallowed is not None:
             self.output['cpusallowed'][self.hostname] = self.cpusallowed
+        if self.gpusallowed is not None:
+            self.output['gpusallowed'][self.hostname] = self.gpusallowed
 
         self.cpusallowed = None
+        self.gpusallowed = None
         self.hostname = None
 
         self._job.adddata(self.name, self.output)
 
     def process(self, mdata):
+        gpusallowed = []
         for metricname, metric in self.allmetrics.items():
-            query = metric['metric'].format(node=mdata.nodename, jobid=self._job.job_id, rate=self.rate)
+            query = metric['metric'].format(node=mdata.nodename, jobid=self._job.job_id, rate=self.rate, job_gpu_info=self.job_gpu_info)
             data = self.query_range(query, mdata.start, mdata.end)
             if data is None:
                 continue
@@ -59,13 +68,17 @@ class ProcPrometheus(PrometheusPlugin):
                     if value:
                         self.cpusallowed = value
                         break
+                elif metricname == 'gpusallowed':
+                    value = m.get('gpu', "")
+                    if value:
+                        gpusallowed.append(value)
                 elif metricname == 'processes':
                     execname = m.get('exec', None)
                     if execname is None:
                         continue
                     if execname not in self.output['procDump']['constrained']:
                         self.output['procDump']['constrained'].append(execname)
-
+        self.gpusallowed = gpusallowed
         return True
 
     def results(self):
@@ -73,6 +86,7 @@ class ProcPrometheus(PrometheusPlugin):
             "constrained": [],
             "unconstrained": [],
             "cpusallowed": {},
+            "gpusallowed": {},
         }
 
         for hostname, value in self.output['cpusallowed'].items():
@@ -80,6 +94,11 @@ class ProcPrometheus(PrometheusPlugin):
                 result['cpusallowed'][hostname] = value
             else:
                 result['cpusallowed'][hostname] = ','.join(value)
+        for hostname, value in self.output['gpusallowed'].items():
+            if 'error' in value:
+                result['gpusallowed'][hostname] = value
+            else:
+                result['gpusallowed'][hostname] = ','.join(value)
         result['constrained'] = self.output['procDump']['constrained']
             
         return {'procDump': result}

--- a/src/supremm/preprocessors/ProcPrometheus.py
+++ b/src/supremm/preprocessors/ProcPrometheus.py
@@ -57,7 +57,7 @@ class ProcPrometheus(PrometheusPlugin):
 
     def process(self, mdata):
         for metricname, metric in self.allmetrics.items():
-            query = metric['metric'].format(node=mdata.nodename, jobid=self._job.job_id, rate='5m')
+            query = metric['metric'].format(node=mdata.nodename, jobid=self._job.job_id, rate=self.rate)
             data = self.query(query, mdata.start, mdata.end)
             if data is None:
                 self._error = ProcessingError.PROMETHEUS_QUERY_ERROR

--- a/src/supremm/preprocessors/ProcPrometheus.py
+++ b/src/supremm/preprocessors/ProcPrometheus.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+""" Proc information pre-processor 
+https://github.com/treydock/cgroup_exporter
+https://github.com/prometheus/node_exporter
+"""
+
+from collections import Counter
+from supremm.plugin import PrometheusPlugin
+from supremm.errors import ProcessingError
+
+class ProcPrometheus(PrometheusPlugin):
+    """ Parse and analyse the proc information for a job. Supports parsing the cgroup information
+        from SLRUM and PBS/Torque (if available).
+    """
+
+    name = property(lambda x: "proc")
+    metric_system = property(lambda x: "prometheus")
+    mode = property(lambda x: "timeseries")
+    requiredMetrics = property(lambda x: {
+        'cpusallowed': {
+            'metric': 'cgroup_cpu_info{{instance=~"^{node}.+"}} * on(cgroup, instance) group_left(jobid) cgroup_info{{instance=~"^{node}.+",jobid="{jobid}"}}',
+        },
+        'hostcpus': {
+            'metric': 'count by(instance) (node_cpu_info{{instance=~"{node}.+"}})',
+        }
+    })
+
+    optionalMetrics = property(lambda x: {})
+    derivedMetrics = property(lambda x: {})
+
+    def __init__(self, job, config):
+        super(ProcPrometheus, self).__init__(job, config)
+
+        self.cpusallowed = None
+        self.hostcpus = None
+        self.hostname = None
+        self.output = {"procDump": {"constrained": Counter(), "unconstrained": Counter()}, "cpusallowed": {}, "hostcpus": {}}
+
+    def hoststart(self, hostname):
+        self.hostname = hostname
+        self.output['cpusallowed'][hostname] = {"error": ProcessingError.RAW_COUNTER_UNAVAILABLE}
+        self.output['hostcpus'][hostname] = {"error": ProcessingError.RAW_COUNTER_UNAVAILABLE}
+
+    def hostend(self):
+        if self.cpusallowed is not None:
+            self.output['cpusallowed'][self.hostname] = self.cpusallowed
+        if self.hostcpus is not None:
+            self.output['hostcpus'][self.hostname] = self.hostcpus
+
+        self.cpusallowed = None
+        self.hostcpus = None
+        self.hostname = None
+
+        self._job.adddata(self.name, self.output)
+
+    def process(self, mdata):
+        for metricname, metric in self.allmetrics.items():
+            query = metric['metric'].format(node=mdata.nodename, jobid=self._job.job_id, rate='5m')
+            data = self.query(query, mdata.start, mdata.end)
+            if data is None:
+                self._error = ProcessingError.PROMETHEUS_QUERY_ERROR
+                return None
+            for r in data.get('data', {}).get('result', []):
+                values = r.get('values', [])
+                m = r.get('metric', {})
+                if len(values) == 0:
+                    continue
+                if metricname == 'cpusallowed':
+                    value = m.get('cpus', "").split(",")
+                    self.cpusallowed = value
+                elif metricname == 'hostcpus':
+                    value = float(values[0][1])
+                    self.hostcpus = value
+
+        return True
+
+    def results(self):
+        if self._error != None:
+            return {"error": self._error}
+
+        result = {"constrained": [],
+                  "unconstrained": [],
+                  "cpusallowed": {}}
+
+        for metric, values in self.output.items():
+            result[metric] = {}
+            for hostname, value in values.items():
+                result[metric][hostname] = value
+            
+        return {'procDump': result}

--- a/src/supremm/scripthelpers.py
+++ b/src/supremm/scripthelpers.py
@@ -80,5 +80,6 @@ def setuplogger(consolelevel, filename=None, filelevel=None):
     consolehandler.setLevel(consolelevel)
     consolehandler.setFormatter(formatter)
     rootlogger.addHandler(consolehandler)
-    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger('urllib3.connectionpool').setLevel(logging.ERROR)
+    logging.getLogger('requests').setLevel(logging.ERROR)
 

--- a/src/supremm/scripthelpers.py
+++ b/src/supremm/scripthelpers.py
@@ -7,6 +7,7 @@ import MySQLdb
 import MySQLdb.cursors
 import sys
 import logging
+import requests
 
 def parsetime(strtime):
     """ Try to be flexible in the time formats supported:
@@ -79,4 +80,5 @@ def setuplogger(consolelevel, filename=None, filelevel=None):
     consolehandler.setLevel(consolelevel)
     consolehandler.setFormatter(formatter)
     rootlogger.addHandler(consolehandler)
+    logging.getLogger("requests").setLevel(logging.WARNING)
 

--- a/src/supremm/summarize.py
+++ b/src/supremm/summarize.py
@@ -123,7 +123,6 @@ class Summarize(object):
             for analytic in self.alltimestamps:
                 try:
                     success = analytic.process(mdata)
-                    self.archives_processed += 1
                     analytic.status = "complete"
                 except Exception as exc:
                     success -= 1
@@ -132,6 +131,7 @@ class Summarize(object):
                     analytic.status = "failed"
                     if self.fail_fast:
                         raise
+            self.archives_processed += 1
                 
 
         return success == 0

--- a/src/supremm/summarize.py
+++ b/src/supremm/summarize.py
@@ -181,7 +181,7 @@ class Summarize(object):
         output['acct']['id'] = self.job.job_id
 
         if len(timeseries) > 0:
-            timeseries['hosts'] = dict((str(idx), name) for name, idx, _ in self.job.nodearchives())
+            timeseries['hosts'] = dict((str(jobnode.nodeindex), node) for node, jobnode in self.job.nodes.items())
             timeseries['version'] = TIMESERIES_VERSION
             output['timeseries'] = timeseries
 

--- a/src/supremm/summarize.py
+++ b/src/supremm/summarize.py
@@ -99,7 +99,7 @@ class Summarize(object):
         """ Main entry point for Prometheus."""
         success = 0
         self.archives_processed = 0
-        print self.job.nodes
+
         for node, jobnode in self.job.nodes.items():
             nodeidx = jobnode.nodeindex
             start_time = self.job.start_datetime

--- a/src/supremm/summarize.py
+++ b/src/supremm/summarize.py
@@ -116,7 +116,7 @@ class Summarize(object):
                     preproc.process(mdata)
                 except Exception as exp:
                     #pylint: disable=not-callable
-                    self.adderror("preprocessor", "{0}: Exception: {1}. {2}".format(preproc.name, str(exc), traceback.format_exc()))
+                    self.adderror("preprocessor", "{0}: Exception: {1}. {2}".format(preproc.name, str(exp), traceback.format_exc()))
                     preproc.status = "failure"
                     preproc.hostend()
                     raise exp

--- a/src/supremm/summarize.py
+++ b/src/supremm/summarize.py
@@ -115,6 +115,8 @@ class Summarize(object):
                 try:
                     preproc.process(mdata)
                 except Exception as exp:
+                    #pylint: disable=not-callable
+                    self.adderror("preprocessor", "{0}: Exception: {1}. {2}".format(preproc.name, str(exc), traceback.format_exc()))
                     preproc.status = "failure"
                     preproc.hostend()
                     raise exp

--- a/src/supremm/summarize_jobs.py
+++ b/src/supremm/summarize_jobs.py
@@ -114,9 +114,9 @@ def process_resource(resconf, preprocs, plugins, config, opts):
 def process_resource_multiprocessing(resconf, preprocs, plugins, config, opts, pool):
     with outputter.factory(config, resconf, dry_run=opts['dry_run']) as m:
         if resconf['batch_system'] == "XDMoD":
-            dbif = XDMoDAcct(resconf['resource_id'], config)
+            dbif = XDMoDAcct(resconf['resource_id'], config, resconf)
         else:
-            dbif = DbAcct(resconf['resource_id'], config)
+            dbif = DbAcct(resconf['resource_id'], config, resconf)
 
         jobs = get_jobs(opts, dbif)
 

--- a/src/supremm/summarize_jobs.py
+++ b/src/supremm/summarize_jobs.py
@@ -86,9 +86,9 @@ def process_resource(resconf, preprocs, plugins, config, opts):
     with outputter.factory(config, resconf, dry_run=opts["dry_run"]) as m:
 
         if resconf['batch_system'] == "XDMoD":
-            dbif = XDMoDAcct(resconf['resource_id'], config)
+            dbif = XDMoDAcct(resconf['resource_id'], config, resconf)
         else:
-            dbif = DbAcct(resconf['resource_id'], config)
+            dbif = DbAcct(resconf['resource_id'], config, resconf)
 
         for job in get_jobs(opts, dbif):
             try:


### PR DESCRIPTION
This is what my configs look like on my test system:

```json
    "summary": {
        "prometheus_url": "https://prometheus.infra.osc.edu",
        "rates": {
            "gpfs": "15m"
        },
...

    "resources": {
        "owens": {
            "enabled": true,
            "resource_id": 1,
            "batch_system": "XDMoD",
            "script_dir": "/systems/supremm_data/jobscripts/owens",
            "metric_system": "prometheus"
        },
```

The default behavior of using PCP is used if `metric_system` is not defined.