### PR TITLE
Fix another edge case error handling in the Performance Counter plugin.

### DIFF
--- a/src/supremm/plugins/CpuPerfCounters.py
+++ b/src/supremm/plugins/CpuPerfCounters.py
@@ -130,12 +130,12 @@ class CpuPerfCounters(Plugin):
         if hasFlops:
             results['flops'] = calculate_stats(flops)
 
-        if numpy.isfinite(cpiref).any():
+        if numpy.isfinite(cpiref).all():
             results['cpiref'] = calculate_stats(cpiref)
         else:
             results['cpiref'] = {"error": ProcessingError.RAW_COUNTER_UNAVAILABLE}
 
-        if hasCpld and numpy.isfinite(cpldref).any():
+        if hasCpld and numpy.isfinite(cpldref).all():
             results['cpldref'] = calculate_stats(cpldref)
         else:
             results['cpldref'] = {"error": ProcessingError.RAW_COUNTER_UNAVAILABLE}


### PR DESCRIPTION
Handle case where a subset of the perf counters had erroneous values. An example
of when this can happen is if some of the counters are multiplexed and
do not have a high enough duty cycle to produce accurate data.

This one would have been caught in 1.4.0 but missed in 1.4.1.