### PR TITLE
Allow defining path to config via SUPREMM_CONFIG_DIR

### DIFF
--- a/src/supremm/config.py
+++ b/src/supremm/config.py
@@ -47,12 +47,14 @@ class Config(object):
     def autodetectconfpath():
         """ search known paths for the configuration directory
             List of paths support the three typical install locations
-            1) source install with pip
-            2) rpm based install
-            3) source install with python setup.py install
+            1) Environment variable SUPREMM_CONFIG_DIR
+            2) source install with pip
+            3) rpm based install
+            4) source install with python setup.py install
             @returns Directory name or None if no suitable directory found
         """
         searchpaths = [
+            os.getenv('SUPREMM_CONFIG_DIR', '/etc/supremm'),
             os.path.dirname(os.path.abspath(__file__)) + "/../../../../etc/supremm",
             "/etc/supremm",
             pkg_resources.resource_filename(pkg_resources.Requirement.parse("supremm"), "etc/supremm")


### PR DESCRIPTION
While doing development I needed a way to store and modify the SUPREMM configs in my home directory and the code was installed into a virtualenv and so the solution I landed on was setting `SUPREMM_CONFIG_DIR` environment variable.