### PR TITLE
Modify CpuUsage plugin to generate additional metrics for hyperthreaded cores

### DIFF
--- a/src/supremm/plugin.py
+++ b/src/supremm/plugin.py
@@ -60,6 +60,12 @@ class NodeMetadata(object):
         """ returns a unique numerical identifier for the node """
         pass
 
+    @property
+    @abstractmethod
+    def hyperthreadedratio(self):
+        """ returns a numerical value indicating the virtual-to-physical ratio for hyperthreaded cores """
+        pass
+
 class Plugin(object):
     """ abstract base class describing the plugin interface """
     __metaclass__ = ABCMeta

--- a/src/supremm/proc_common.py
+++ b/src/supremm/proc_common.py
@@ -320,7 +320,7 @@ def summarizejob(job, conf, resconf, plugins, preprocs, opts):
 
     preprocessors = instantiatePlugins(preprocs, job)
     analytics = instantiatePlugins(plugins, job)
-    s = Summarize(preprocessors, analytics, job, conf, opts["fail_fast"])
+    s = Summarize(preprocessors, analytics, job, conf, resconf, opts["fail_fast"])
 
     enough_nodes = False
 


### PR DESCRIPTION
The CpuUsage plugin now generates additional metrics when hyperthreading is on. Hyperthreading is indicated by providing the ratio of virtual/physical cores in a config file.