### PR TITLE
Use multithreaded archive indexing by default.

### DIFF
--- a/src/supremm/supremm_update
+++ b/src/supremm/supremm_update
@@ -27,7 +27,7 @@ reportfail()
     # Run index and ingest
     
     if [ "$1" != "process" ]; then
-        indexarchives.py
+        indexarchives.py -t $THREADS -q
         summarize_jobs.py -t $THREADS -q
     else
         summarize_jobs.py -t $THREADS -d


### PR DESCRIPTION
The example supremm_update script had inconsistent commandline
flags between the indexarchives step and the summarization.

This updates the default commandline for the indexarchives to be
consistent: quiet logging mode and multithreaded scanning.