### PR TITLE
Add plugin for RAPL measurements. 

### DIFF
--- a/src/supremm/assets/mongo_setup.js
+++ b/src/supremm/assets/mongo_setup.js
@@ -435,6 +435,42 @@ var summarydef = {
             "documentation": "Categorization of the CPU utilization of the job as good, pinned, unpinned, or low. A job is good if every core is heavily utilized, and a job is low if the cores are barely utilized or not at all. A pinned job consists of a scenario where a subset of the cores does most of the work, while an unpinned job is when the work is spread unevenly across many cores.",
             "type": "",
             "unit": ""
+        },
+        "rapl": {
+            "energy" : {
+                "pkg" : {
+                    "documentation": "",
+                    "type": "",
+                    "unit": "Joules"
+                },
+                "cores" : {
+                    "documentation": "",
+                    "type": "",
+                    "unit": "Joules"
+                },
+                "dram" : {
+                    "documentation": "",
+                    "type": "",
+                    "unit": "Joules"
+                }
+            },
+            "power": {
+                "pkg" : {
+                    "documentation": "",
+                    "type": "",
+                    "unit": "Watts"
+                },
+                "cores" : {
+                    "documentation": "",
+                    "type": "",
+                    "unit": "Watts"
+                },
+                "dram" : {
+                    "documentation": "",
+                    "type": "",
+                    "unit": "Watts"
+                }
+            }
         }
     } 
 };

--- a/src/supremm/plugins/RAPL.py
+++ b/src/supremm/plugins/RAPL.py
@@ -16,9 +16,9 @@ class RAPL(Plugin):
     optionalMetrics = property(lambda x: [])
     derivedMetrics = property(lambda x: [])
 
-    # Scaling factor to convert RAPL energy measurements to Joules 
+    # Scaling factor to convert RAPL energy measurements to Joules
     scaleFactor = 2**(-32)
-   
+
     def __init__(self, job):
         super(RAPL, self).__init__(job)
         self._first = {}
@@ -69,7 +69,7 @@ class RAPL(Plugin):
 
             wallTime = data['time']
 
-        # Return energy in Joules and power in Watts (J/s)  
+        # Return energy in Joules and power in Watts (J/s)
         return {
             "power":{
                 "pkg": calculate_stats(pkgArray)['avg']/wallTime,

--- a/src/supremm/plugins/RAPL.py
+++ b/src/supremm/plugins/RAPL.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+""" RAPL Power Counter Measurements """
+
+from supremm.plugin import Plugin
+from supremm.statistics import calculate_stats
+from supremm.errors import ProcessingError
+import numpy
+
+class RAPL(Plugin):
+
+    name = property(lambda x: "rapl")
+    mode = property(lambda x: "firstlast")
+    requiredMetrics = property(lambda x: [["perfevent.hwcounters.rapl__RAPL_ENERGY_PKG.value",
+                                            "perfevent.hwcounters.rapl__RAPL_ENERGY_CORES.value",
+                                            "perfevent.hwcounters.rapl__RAPL_ENERGY_DRAM.value"]])
+    optionalMetrics = property(lambda x: [])
+    derivedMetrics = property(lambda x: [])
+
+    # Scaling factor to convert RAPL energy measurements to Joules 
+    scaleFactor = 2**(-32)
+   
+    def __init__(self, job):
+        super(RAPL, self).__init__(job)
+        self._first = {}
+        self._data = {}
+        self._error = None
+        self._totalcores = 0
+
+    def process(self, nodemeta, timestamp, data, description):
+
+        ndata = numpy.array(data)
+
+        if nodemeta.nodename not in self._first:
+            self._first[nodemeta.nodename] = {
+                'energy': ndata,
+                'time' : timestamp
+            }
+            return True
+        if ndata.shape == self._first[nodemeta.nodename]['energy'].shape:
+            self._data[nodemeta.nodename] = {
+                'energy': ndata - self._first[nodemeta.nodename]['energy'],
+                'time': timestamp - self._first[nodemeta.nodename]['time']
+            }
+
+            self._totalcores += data[0].size
+        else:
+            self._error = ProcessingError.RAW_COUNTER_UNAVAILABLE
+            return False
+
+        return True
+
+    def results(self):
+        if self._error != None:
+            return {"error": self._error}
+
+        nhosts = len(self._data)
+
+        if nhosts < 1:
+            return {"error": ProcessingError.INSUFFICIENT_HOSTDATA}
+
+        pkgArray = numpy.zeros(self._totalcores)
+        coresArray = numpy.zeros(self._totalcores)
+        dramArray = numpy.zeros(self._totalcores)
+
+        for _, data in self._data.iteritems():
+            pkgArray = numpy.multiply(data['energy'][0], self.scaleFactor)
+            coresArray = numpy.multiply(data['energy'][1], self.scaleFactor)
+            dramArray = numpy.multiply(data['energy'][2], self.scaleFactor)
+
+            wallTime = data['time']
+
+        # Return energy in Joules and power in Watts (J/s)  
+        return {
+            "power":{
+                "pkg": calculate_stats(pkgArray)['avg']/wallTime,
+                "cores": calculate_stats(coresArray)['avg']/wallTime,
+                "dram": calculate_stats(dramArray)['avg']/wallTime
+            },
+            "energy": {
+                "pkg": calculate_stats(pkgArray),
+                "cores": calculate_stats(coresArray),
+                "dram": calculate_stats(dramArray)
+            },
+        }
+
+


### PR DESCRIPTION
Start on the RAPL Plugin for getting power measurements. Currently outputs energy and power measurements for the package value, cores value, and dram value. 

rapl::RAPL_ENERGY_PKG : power consumption of all cores + LLC cache
rapl::RAPL_ENERGY_CORES : power consumption of all cores on socket
rapl::RAPL_ENERGY_DRAM : power consumption of DRAM (servers only)