### PR TITLE
Fix encoding of string data from PCP.

### DIFF
--- a/src/supremm/pcpcinterface/pcpcinterface.pyx
+++ b/src/supremm/pcpcinterface/pcpcinterface.pyx
@@ -34,7 +34,7 @@ cdef class Pool:
 
 cdef object topyobj(c_pcp.pmAtomValue atom, int dtype):
     if dtype == c_pcp.PM_TYPE_STRING:
-        ret = str(atom.cp)
+        ret = str(atom.cp, 'utf-8')
         free(atom.cp)
         return ret
     elif dtype == c_pcp.PM_TYPE_32:
@@ -61,7 +61,7 @@ cdef object strinnerloop(int numval, c_pcp.pmResult* res, int i):
         status = c_pcp.pmExtractValue(res.vset[i].valfmt, &res.vset[i].vlist[j], c_pcp.PM_TYPE_STRING, &atom, c_pcp.PM_TYPE_STRING)
         if status < 0:
             raise pmapi.pmErr(status)
-        tmp_data.append(str(atom.cp))
+        tmp_data.append(str(atom.cp, 'utf-8'))
         free(atom.cp)
     return numpy.array(tmp_data)
 
@@ -361,7 +361,7 @@ def extractpreprocValues(context, result, py_metric_id_array, mtypes):
             mem.add(inames)
             tmp_dict = dict()
             for j in xrange(status):
-                tmp_dict[ivals[j]] = inames[j]
+                tmp_dict[ivals[j]] = str(inames[j], 'utf-8')
             description.append(tmp_dict)
 
     # Initialize data

--- a/src/supremm/preprocessors/Proc.py
+++ b/src/supremm/preprocessors/Proc.py
@@ -116,7 +116,7 @@ class Proc(PreProcessor):
                 self.logerror("missing process name")
                 continue
 
-            s = str(description[1][pid], errors='replace')
+            s = description[1][pid]
             command = s[s.find(" ") + 1:]
 
             if self.cgroupparser is not None:


### PR DESCRIPTION
I've been working with the latest SUPREMM beta on RHEL 8, and have found a bug that was causing missing/erroneous data on the Job Viewer page under the Executable Information tab.

The root cause of the problem is that when the module is pulling strings from PCP via pmlogextract, it's getting them as byte arrays, and apparently (at least) with python3.6, using str() on byte array "foo" encodes the resulting string as the literal "b'foo'".  This errant string then doesn't match the string "foo" and causes the missing data.

There are minor fixes to:
src/supremm/pcpcinterface/pcpcinterface.pyx
replacing the three occurrences of str(foo) with str(foo, 'utf-8')

and a fix to src/supremm/preprocessors/Proc.py
to remove a now unnecessary str() call due to the above change.