### PR TITLE
Support setup for different versions of Mongo

### DIFF
--- a/src/supremm/assets/mongo_setup.js
+++ b/src/supremm/assets/mongo_setup.js
@@ -445,6 +445,6 @@ if (version < 5) {
     db.schema.update({_id: sdef._id}, sdef, {upsert: true});
     db.schema.update({_id: summarydef._id}, summarydef, {upsert: true});
 } else {
-    db.schema.updateOne({_id: summarydef._id}, {$set: summarydef}, {upsert: true});
+    db.schema.updateOne({_id: sdef._id}, {$set: sdef}, {upsert: true});
     db.schema.updateOne({_id: summarydef._id}, {$set: summarydef}, {upsert: true});
 }

--- a/src/supremm/assets/mongo_setup.js
+++ b/src/supremm/assets/mongo_setup.js
@@ -440,5 +440,11 @@ var summarydef = {
 };
 
 db = db.getSiblingDB("supremm");
-db.schema.update({_id: sdef._id}, sdef, {upsert: true});
-db.schema.update({_id: summarydef._id}, summarydef, {upsert: true});
+var version = parseFloat(db.version());
+if (version < 5) {
+    db.schema.update({_id: sdef._id}, sdef, {upsert: true});
+    db.schema.update({_id: summarydef._id}, summarydef, {upsert: true});
+} else {
+    db.schema.updateOne({_id: summarydef._id}, {$set: summarydef}, {upsert: true});
+    db.schema.updateOne({_id: summarydef._id}, {$set: summarydef}, {upsert: true});
+}


### PR DESCRIPTION
This PR fixes the mongo_setup.js script to populate the schema definition with the appropriate function based on the Mongo shell version.

This change is necessary because the update() function is deprecated in versions of the Mongo shell greater than 5.0.

These changes were tested with successful results on both Mongo 4.4 and Mongo 6.0.