### PR TITLE
Update Python list indexing with integer division

### DIFF
--- a/src/supremm/plugin.py
+++ b/src/supremm/plugin.py
@@ -341,14 +341,14 @@ class RateConvertingTimeseriesPlugin(Plugin, metaclass=ABCMeta):
             retdata = {
                 "min": self.collatedata(sortarr[:, 0], rates),
                 "max": self.collatedata(sortarr[:, -1], rates),
-                "med": self.collatedata(sortarr[:, sortarr.shape[1] / 2], rates),
+                "med": self.collatedata(sortarr[:, sortarr.shape[1] // 2], rates),
                 "times": values[0, 1:, 0].tolist(),
                 "hosts": {}
             }
 
             uniqhosts = Counter(sortarr[:, 0])
             uniqhosts.update(sortarr[:, -1])
-            uniqhosts.update(sortarr[:, sortarr.shape[1] / 2])
+            uniqhosts.update(sortarr[:, sortarr.shape[1] // 2])
             includelist = list(uniqhosts.keys())
         else:
             # Save data for all hosts

--- a/src/supremm/plugins/ArmPowerUsageTimeseries.py
+++ b/src/supremm/plugins/ArmPowerUsageTimeseries.py
@@ -83,14 +83,14 @@ class ArmPowerUsageTimeseries(Plugin):
             retdata = {
                 "min": self.collatedata(sortarr[:, 0], rates),
                 "max": self.collatedata(sortarr[:, -1], rates),
-                "med": self.collatedata(sortarr[:, sortarr.shape[1] / 2], rates),
+                "med": self.collatedata(sortarr[:, sortarr.shape[1] // 2], rates),
                 "times": values[0, 1:, 0].tolist(),
                 "hosts": {}
             }
 
             uniqhosts = Counter(sortarr[:, 0])
             uniqhosts.update(sortarr[:, -1])
-            uniqhosts.update(sortarr[:, sortarr.shape[1] / 2])
+            uniqhosts.update(sortarr[:, sortarr.shape[1] // 2])
             includelist = uniqhosts.keys()
         else:
             # Save data for all hosts

--- a/src/supremm/plugins/CgroupMemTimeseries.py
+++ b/src/supremm/plugins/CgroupMemTimeseries.py
@@ -87,14 +87,14 @@ class CgroupMemTimeseries(Plugin):
             retdata = {
                 "min": self.collatedata(sortarr[:, 0], memdata),
                 "max": self.collatedata(sortarr[:, -1], memdata),
-                "med": self.collatedata(sortarr[:, sortarr.shape[1] / 2], memdata),
+                "med": self.collatedata(sortarr[:, sortarr.shape[1] // 2], memdata),
                 "times": values[0, :, 0].tolist(),
                 "hosts": {}
             }
 
             uniqhosts = Counter(sortarr[:, 0])
             uniqhosts.update(sortarr[:, -1])
-            uniqhosts.update(sortarr[:, sortarr.shape[1] / 2])
+            uniqhosts.update(sortarr[:, sortarr.shape[1] // 2])
             includelist = list(uniqhosts.keys())
         else:
             # Save data for all hosts

--- a/src/supremm/plugins/CpuUserTimeseries.py
+++ b/src/supremm/plugins/CpuUserTimeseries.py
@@ -79,14 +79,14 @@ class CpuUserTimeseries(Plugin):
             retdata = {
                 "min": self.collatedata(sortarr[:, 0], rates),
                 "max": self.collatedata(sortarr[:, -1], rates),
-                "med": self.collatedata(sortarr[:, sortarr.shape[1] / 2], rates),
+                "med": self.collatedata(sortarr[:, sortarr.shape[1] // 2], rates),
                 "times": values[0, 1:, 0].tolist(),
                 "hosts": {}
             }
 
             uniqhosts = Counter(sortarr[:, 0])
             uniqhosts.update(sortarr[:, -1])
-            uniqhosts.update(sortarr[:, sortarr.shape[1] / 2])
+            uniqhosts.update(sortarr[:, sortarr.shape[1] // 2])
             includelist = list(uniqhosts.keys())
         else:
             # Save data for all hosts

--- a/src/supremm/plugins/GpuUsageTimeseries.py
+++ b/src/supremm/plugins/GpuUsageTimeseries.py
@@ -55,14 +55,14 @@ class GpuUsageTimeseries(Plugin):
             retdata = {
                 "min": self.collatedata(sortarr[:, 0], memdata),
                 "max": self.collatedata(sortarr[:, -1], memdata),
-                "med": self.collatedata(sortarr[:, sortarr.shape[1] / 2], memdata),
+                "med": self.collatedata(sortarr[:, sortarr.shape[1] // 2], memdata),
                 "times": values[0, :, 0].tolist(),
                 "hosts": {}
             }
 
             uniqhosts = Counter(sortarr[:, 0])
             uniqhosts.update(sortarr[:, -1])
-            uniqhosts.update(sortarr[:, sortarr.shape[1] / 2])
+            uniqhosts.update(sortarr[:, sortarr.shape[1] // 2])
             includelist = list(uniqhosts.keys())
         else:
             # Save data for all hosts

--- a/src/supremm/plugins/MemBwTimeseries.py
+++ b/src/supremm/plugins/MemBwTimeseries.py
@@ -91,14 +91,14 @@ class MemBwTimeseries(Plugin):
             retdata = {
                 "min": self.collatedata(sortarr[:, 0], rates),
                 "max": self.collatedata(sortarr[:, -1], rates),
-                "med": self.collatedata(sortarr[:, sortarr.shape[1] / 2], rates),
+                "med": self.collatedata(sortarr[:, sortarr.shape[1] // 2], rates),
                 "times": values[0, 1:, 0].tolist(),
                 "hosts": {}
             }
 
             uniqhosts = Counter(sortarr[:, 0])
             uniqhosts.update(sortarr[:, -1])
-            uniqhosts.update(sortarr[:, sortarr.shape[1] / 2])
+            uniqhosts.update(sortarr[:, sortarr.shape[1] // 2])
             includelist = list(uniqhosts.keys())
         else:
             # Save data for all hosts

--- a/src/supremm/plugins/MemUsageTimeseries.py
+++ b/src/supremm/plugins/MemUsageTimeseries.py
@@ -55,14 +55,14 @@ class MemUsageTimeseries(Plugin):
             retdata = {
                 "min": self.collatedata(sortarr[:, 0], memdata),
                 "max": self.collatedata(sortarr[:, -1], memdata),
-                "med": self.collatedata(sortarr[:, sortarr.shape[1] / 2], memdata),
+                "med": self.collatedata(sortarr[:, sortarr.shape[1] // 2], memdata),
                 "times": values[0, :, 0].tolist(),
                 "hosts": {}
             }
 
             uniqhosts = Counter(sortarr[:, 0])
             uniqhosts.update(sortarr[:, -1])
-            uniqhosts.update(sortarr[:, sortarr.shape[1] / 2])
+            uniqhosts.update(sortarr[:, sortarr.shape[1] // 2])
             includelist = list(uniqhosts.keys())
         else:
             # Save data for all hosts

--- a/src/supremm/plugins/PowerUsageTimeseries.py
+++ b/src/supremm/plugins/PowerUsageTimeseries.py
@@ -67,14 +67,14 @@ class PowerUsageTimeseries(Plugin):
             retdata = {
                 "min": self.collatedata(sortarr[:, 0], power),
                 "max": self.collatedata(sortarr[:, -1], power),
-                "med": self.collatedata(sortarr[:, sortarr.shape[1] / 2], power),
+                "med": self.collatedata(sortarr[:, sortarr.shape[1] // 2], power),
                 "times": values[0, :, 0].tolist(),
                 "hosts": {}
             }
 
             uniqhosts = Counter(sortarr[:, 0])
             uniqhosts.update(sortarr[:, -1])
-            uniqhosts.update(sortarr[:, sortarr.shape[1] / 2])
+            uniqhosts.update(sortarr[:, sortarr.shape[1] // 2])
             includelist = list(uniqhosts.keys())
         else:
             # Save data for all hosts

--- a/src/supremm/plugins/SimdInsTimeseries.py
+++ b/src/supremm/plugins/SimdInsTimeseries.py
@@ -87,14 +87,14 @@ class SimdInsTimeseries(Plugin):
             retdata = {
                 "min": self.collatedata(sortarr[:, 0], rates),
                 "max": self.collatedata(sortarr[:, -1], rates),
-                "med": self.collatedata(sortarr[:, sortarr.shape[1] / 2], rates),
+                "med": self.collatedata(sortarr[:, sortarr.shape[1] // 2], rates),
                 "times": values[0, 1:, 0].tolist(),
                 "hosts": {}
             }
 
             uniqhosts = Counter(sortarr[:, 0])
             uniqhosts.update(sortarr[:, -1])
-            uniqhosts.update(sortarr[:, sortarr.shape[1] / 2])
+            uniqhosts.update(sortarr[:, sortarr.shape[1] // 2])
             includelist = list(uniqhosts.keys())
         else:
             # Save data for all hosts

--- a/src/supremm/plugins/SveTimeseries.py
+++ b/src/supremm/plugins/SveTimeseries.py
@@ -79,14 +79,14 @@ class SveTimeseries(Plugin):
             retdata = {
                 "min": self.collatedata(sortarr[:, 0], rates),
                 "max": self.collatedata(sortarr[:, -1], rates),
-                "med": self.collatedata(sortarr[:, sortarr.shape[1] / 2], rates),
+                "med": self.collatedata(sortarr[:, sortarr.shape[1] // 2], rates),
                 "times": values[0, 1:, 0].tolist(),
                 "hosts": {}
             }
 
             uniqhosts = Counter(sortarr[:, 0])
             uniqhosts.update(sortarr[:, -1])
-            uniqhosts.update(sortarr[:, sortarr.shape[1] / 2])
+            uniqhosts.update(sortarr[:, sortarr.shape[1] // 2])
             includelist = uniqhosts.keys()
         else:
             # Save data for all hosts

--- a/src/supremm/plugins/TotalMemUsageTimeseries.py
+++ b/src/supremm/plugins/TotalMemUsageTimeseries.py
@@ -62,7 +62,7 @@ class TotalMemUsageTimeseries(Plugin):
 
             uniqhosts = Counter(sortarr[:, 0])
             uniqhosts.update(sortarr[:, -1])
-            uniqhosts.update(sortarr[:, sortarr.shape[1] / 2])
+            uniqhosts.update(sortarr[:, sortarr.shape[1] // 2])
             includelist = list(uniqhosts.keys())
         else:
             # Save data for all hosts


### PR DESCRIPTION
I encountered an issue with these plugins when summarizing jobs with more than 64 nodes. Python requires list indices to be integers, however Python 3 explicitly requires "//" for integer division.

This was hotfixed and tested on Rocky 8 Ookami.