### PR TITLE
Add 'datasource' field to output summarization record

### DIFF
--- a/src/supremm/datasource/pcp/pcpsummarize.py
+++ b/src/supremm/datasource/pcp/pcpsummarize.py
@@ -100,7 +100,9 @@ class PCPSummarize(Summarize):
             "elapsed": time.time() - self.start,
             "created": time.time(),
             "srcdir": self.job.jobdir,
-            "complete": self.complete()}
+            "complete": self.complete(),
+            "datasource": "pcp"
+        }
 
         output['created'] = datetime.datetime.utcnow()
 

--- a/src/supremm/datasource/prometheus/promsummarize.py
+++ b/src/supremm/datasource/prometheus/promsummarize.py
@@ -55,7 +55,9 @@ class PromSummarize(Summarize):
             "elapsed": time.time() - self.start,
             "created": time.time(),
             "srcdir": self.job.jobdir,
-            "complete": self.complete()}
+            "complete": self.complete(),
+            "datasource": "prometheus",
+        }
 
         output['created'] = datetime.datetime.utcnow()
 

--- a/tests/component/runtests.sh
+++ b/tests/component/runtests.sh
@@ -12,5 +12,6 @@ jq -e .cpuperf.cpldref.avg < $outputfile
 jq -e .uncperf.membw.avg < $outputfile
 jq -e .timeseries.membw < $outputfile
 jq -e .timeseries.simdins < $outputfile
+jq -e .summarization.datasource < $outputfile
 
 rm -f $outputfile


### PR DESCRIPTION
This change is necessary for SUPReMM to work with the changes made in https://github.com/ubccr/xdmod-supremm/pull/346.

If this field is not present in the summarization record, then the Job Performance module assumes the summarization record was generated from PCP data. This behavior ensures backward compatibility with summarization records that do not contain a 'datasource' field because PCP was the only officially supported data source prior to SUPReMM v2.0.0.