### PR TITLE
Remove Prometheus-specific configuration for PCP setup

### DIFF
--- a/src/supremm/supremm_setup.py
+++ b/src/supremm/supremm_setup.py
@@ -316,6 +316,8 @@ WARNING The directory {0} does not exist. Make sure to create and populate this
 directory before running the summarization software.
 """.format(setting[key]))
                     del setting["prom_host"]
+                    del setting["prom_user"]
+                    del setting["prom_password"]
                     break
 
                 elif setting[key] == "prometheus":


### PR DESCRIPTION
### Description
This change prevents any settings specific to Prometheus from appearing in resources configured with PCP.

### Motivation
I was looking through a configuration file in a dev environment and noticed that some default settings for Prometheus were present for a PCP-configured resource. This bug functionally has no impact on summarization of PCP data, however, it can be very confusing for a user to see Prometheus settings in PCP-configured resources.

### Tests
Tested by running `supremm-setup` in the CI docker container. I configured both a PCP and Prometheus resource to ensure the data source settings are mutually exclusive.


