### PR TITLE
Add VictoriaMetrics support 

### DIFF
--- a/src/supremm/datasource/prometheus/prominterface.py
+++ b/src/supremm/datasource/prometheus/prominterface.py
@@ -15,7 +15,7 @@ class PromClient():
     """ Client class to interface with Prometheus """
 
     def __init__(self, resconf):
-        self._url = "http://{}".format(resconf['prom_host'])
+        self._url = resconf['prom_url']
 
         self._client = requests.Session()
         self._client.mount(self._url, self._client.get_adapter(self._url))

--- a/src/supremm/datasource/prometheus/prominterface.py
+++ b/src/supremm/datasource/prometheus/prominterface.py
@@ -36,7 +36,7 @@ class PromClient():
     def build_info(client, test_url):
         """ Query server build info. Test connection to server. """
 
-        endpoint = "/api/v1/status/buildinfo"
+        endpoint = "api/v1/status/buildinfo"
         url = urlparse.urljoin(test_url, endpoint)
 
         r = client.get(url)
@@ -59,7 +59,7 @@ class PromClient():
             'time': time,
         }
 
-        endpoint = "/api/v1/query"
+        endpoint = "api/v1/query"
         url = urlparse.urljoin(self._url, endpoint)
 
         r = self._client.get(url, params=params)
@@ -79,7 +79,7 @@ class PromClient():
             'step': '30s'
         }
 
-        endpoint = "/api/v1/query_range"
+        endpoint = "api/v1/query_range"
         url = urlparse.urljoin(self._url, endpoint)
 
         r = self._client.get(url, params=params)
@@ -98,7 +98,7 @@ class PromClient():
             'end': str(end)
         }
 
-        endpoint = "/api/v1/series"
+        endpoint = "api/v1/series"
         urlparse.urlencode(params, doseq=True)
         url = urlparse.urljoin(self._url, endpoint)
         logging.debug('Prometheus QUERY SERIES META, start=%s end=%s', start, end)
@@ -122,7 +122,7 @@ class PromClient():
         }
 
         urlparse.urlencode(params, doseq=True)
-        url = urlparse.urljoin(self._url, "/api/v1/label/%s/values" % label)
+        url = urlparse.urljoin(self._url, "api/v1/label/%s/values" % label)
         logging.debug('Prometheus QUERY LABEL VALUES, start=%s end=%s', start, end)
 
         # Query data
@@ -147,7 +147,7 @@ class PromClient():
         }
 
         urlparse.urlencode(params, doseq=True)
-        url = urlparse.urljoin(self._url, "/api/v1/label/cgroup/values")
+        url = urlparse.urljoin(self._url, "api/v1/label/cgroup/values")
         logging.debug('Prometheus QUERY CGROUP, start=%s end=%s', start, end)
 
         # Query data


### PR DESCRIPTION
Our site uses VictoriaMetrics as our TSDB. VictoriaMetrics supports the Prometheus v1 Query API, but provides it at a different path , `/select/ID/prometheus`. The hard coded leading slash in the endpoints mangles this path when joined with the base URL. 

By removing the leading slash, and providing the full path in the config,  `https://host:port/select/0/prometheus/`, we have been able to use VictoriaMetrics with Supremm. 

Additionally, we think that the configuration file parameter should just be the full URL, and not the host, so we can use HTTPS. 

This should not have any affect on the Prometheus setups. 

As far as testing, I could not quite get the testing environment set up - but we have been summarizing jobs this way for a few weeks. 